### PR TITLE
feat: improve dual-intent hiring + contract conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ vite.config.ts.timestamp-*
 /.vscode/tasks.json
 .superpowers/
 docs/superpowers/
+
+.context/

--- a/docs/brainstorms/2026-04-30-website-open-work-ideas-requirements.md
+++ b/docs/brainstorms/2026-04-30-website-open-work-ideas-requirements.md
@@ -1,0 +1,67 @@
+# Requirements: Website appeal for hiring + contract leads
+
+Date: 2026-04-30
+Status: Approved in brainstorm
+
+## Goal
+
+Improve adamrobinson.tech so it appeals to:
+
+- Hiring managers seeking a senior engineer
+- Clients seeking contract/consulting help
+
+Both audiences are equal priority over the next 30 days.
+
+## Constraints and context
+
+- Most work is internal/non-public due to consulting context.
+- Two self-built apps are private.
+- Publicly discussable work includes church website + sermon hosting integration.
+- Anonymized case studies are acceptable with review before publishing.
+
+## Conversion priorities
+
+1. Primary CTA: contact form
+2. Secondary CTA: direct email
+3. Supporting CTA: resume download
+
+## What to build (requirements)
+
+- Clear dual-path messaging for full-time and contract intent.
+- Shared trust layer (bio, strengths, process, reliability signals).
+- Persona-specific CTA copy and context collection via contact form.
+- Confidentiality-safe proof strategy:
+  - anonymized case studies (problem, approach, outcome)
+  - optional named/public examples where available
+- Balanced roadmap:
+  - quick wins (copy/IA/CTA polish)
+  - one standout implementation to differentiate the site
+
+## Likely areas to change
+
+- Homepage hero/value proposition and CTA sections
+- About/Work sections for proof framing
+- Contact flow and form fields/messaging
+- Case-study/content structure (including anonymized format)
+
+## Risks / failure modes
+
+- Messaging becomes too generic trying to serve both personas.
+- Over-indexing on confidentiality limits credibility.
+- CTA fragmentation lowers inquiry conversion.
+
+## Success signals
+
+- More qualified contact form submissions
+- Better mix of full-time + contract inquiries
+- Clearer self-reported intent in inbound messages
+
+## Alternatives considered
+
+- Minimal viable: copy + CTA hierarchy + contact form tuning only
+- Ideal architecture: dual-intent IA + anonymized case-study system + standout interactive proof module
+- Recommended: phased balanced mix (quick wins first, then standout feature)
+
+## Next step
+
+Proceed to 02-plan and convert this into implementation units.

--- a/docs/plans/2026-04-30-dual-intent-hiring-contract-conversion-plan.md
+++ b/docs/plans/2026-04-30-dual-intent-hiring-contract-conversion-plan.md
@@ -1,0 +1,187 @@
+# Plan: Dual-intent conversion improvements (hiring + contract)
+
+## Problem summary
+
+Improve site conversion for two equal-priority audiences: hiring managers and contract clients. Keep contact form as primary CTA, email secondary, resume tertiary, while increasing trust despite limited public artifacts.
+
+## Relevant learnings
+
+No relevant solutions found in:
+
+- `docs/solutions/`
+- `~/.pi/agent/docs/solutions/`
+
+## Scope boundaries
+
+In scope:
+
+- Homepage messaging/IA updates for dual intent
+- Contact flow copy + intent capture refinements
+- Anonymized case study framework and first examples
+- Lightweight proof/trust module as standout implementation
+
+Out of scope:
+
+- Backend API redesign for `/api/contact`
+- New third-party UI libraries
+- Large visual rebrand
+
+## Implementation units
+
+### Unit 1 — Dual-intent homepage messaging + CTA hierarchy
+
+**Purpose:** Make audience split and primary conversion obvious above the fold.
+
+**Files:**
+
+- `src/routes/+page.svelte`
+- `src/components/hero-section.svelte`
+- `src/components/trust-strip.svelte`
+- `src/lib/copy.ts`
+- `src/components/__tests__/hero-dual-intent.test.ts` (new)
+
+**Steps:**
+
+- [ ] Write failing tests for hero copy/CTAs covering both intents and CTA order (RED)
+- [ ] Run targeted test and confirm fail: `npm run test -- hero-dual-intent`
+- [ ] Implement minimal copy/layout updates in hero + trust strip (GREEN)
+- [ ] Re-run targeted test and confirm pass: `npm run test -- hero-dual-intent`
+- [ ] Refactor copy constants and section structure for clarity
+- [ ] Run unit-level verification: `npm run check`
+
+**Verification commands:**
+
+- `npm run test -- hero-dual-intent`
+- `npm run check`
+
+**Expected results:**
+
+- Homepage clearly supports both full-time and contract visitors
+- Contact form CTA is most prominent, with email/resume as secondary/supporting
+
+---
+
+### Unit 2 — Contact form intent qualification and message polish
+
+**Purpose:** Increase inquiry quality while preserving low-friction submission.
+
+**Files:**
+
+- `src/components/contact-form.svelte`
+- `src/lib/validation.ts`
+- `src/lib/server/emailTemplates.ts`
+- `src/lib/server/contactEmail.ts`
+- `src/lib/server/__tests__/contact-intent-routing.test.ts` (new)
+
+**Steps:**
+
+- [ ] Add failing tests for new/updated intent fields and validation behavior (RED)
+- [ ] Run targeted test and confirm fail: `npm run test -- contact-intent-routing`
+- [ ] Implement minimal form + validation + email template updates (GREEN)
+- [ ] Re-run targeted test and confirm pass: `npm run test -- contact-intent-routing`
+- [ ] Refactor field names/copy for clarity and consistency
+- [ ] Run unit-level verification: `npm run test -- contact-intent-routing && npm run check`
+
+**Verification commands:**
+
+- `npm run test -- contact-intent-routing`
+- `npm run check`
+
+**Expected results:**
+
+- Contact submissions capture clearer full-time vs contract intent
+- Notification payloads include actionable qualification context
+
+---
+
+### Unit 3 — Anonymized case study system + first publishable entries
+
+**Purpose:** Build trust with confidentiality-safe proof artifacts.
+
+**Files:**
+
+- `src/content/case-studies/` (new folder + markdown entries)
+- `src/lib/server/markdown.ts`
+- `src/routes/work/+page.svelte`
+- `src/components/case-study.svelte`
+- `src/lib/server/__tests__/anonymized-case-study-schema.test.ts` (new)
+
+**Steps:**
+
+- [ ] Write failing tests for required anonymized case-study frontmatter/schema (RED)
+- [ ] Run targeted test and confirm fail: `npm run test -- anonymized-case-study-schema`
+- [ ] Implement loader/schema + render updates and add first 1-2 anonymized studies (GREEN)
+- [ ] Re-run targeted test and confirm pass: `npm run test -- anonymized-case-study-schema`
+- [ ] Refactor content model for future additions
+- [ ] Run unit-level verification: `npm run test -- anonymized-case-study-schema && npm run check:blog-drafts`
+
+**Verification commands:**
+
+- `npm run test -- anonymized-case-study-schema`
+- `npm run check:blog-drafts`
+
+**Expected results:**
+
+- Work surface shows structured, sanitized outcomes without exposing sensitive details
+- Adding future anonymized studies is repeatable
+
+---
+
+### Unit 4 — Standout proof module (interactive outcomes timeline)
+
+**Purpose:** Add one differentiated feature that signals senior-level product engineering.
+
+**Files:**
+
+- `src/components/outcome-proof.svelte`
+- `src/components/recently-shipped.svelte`
+- `src/lib/copy.ts`
+- `src/routes/+page.svelte`
+- `src/components/__tests__/outcome-proof-interactions.test.ts` (new)
+
+**Steps:**
+
+- [ ] Write failing interaction tests for timeline/proof module states (RED)
+- [ ] Run targeted test and confirm fail: `npm run test -- outcome-proof-interactions`
+- [ ] Implement minimal interactive module updates (GREEN)
+- [ ] Re-run targeted test and confirm pass: `npm run test -- outcome-proof-interactions`
+- [ ] Refactor accessibility labels and reduced-motion behavior
+- [ ] Run unit-level verification: `npm run check && npm run build`
+
+**Verification commands:**
+
+- `npm run test -- outcome-proof-interactions`
+- `npm run check`
+- `npm run build`
+
+**Expected results:**
+
+- Home page includes a distinctive, credible proof interaction
+- Accessibility/performance constraints remain intact
+
+## Verification strategy
+
+Targeted per unit first (RED/GREEN proof), then broad checks:
+
+- `npm run test`
+- `npm run check`
+- `npm run lint`
+- `npm run build`
+
+## Assumptions and risks
+
+- Assumption: current Vitest setup supports new component/server tests without framework changes.
+- Risk: some existing files may need cleanup before adding stricter tests.
+- Risk: balancing both audiences may still dilute message; validate copy with real inbound responses.
+
+## Rule loading summary
+
+Loaded rules:
+
+- Common: `development-workflow.md`, `testing.md`
+- TypeScript: `coding-style.md`, `hooks.md`, `patterns.md`, `security.md`, `testing.md`
+- Web: `coding-style.md`, `design-quality.md`, `hooks.md`, `patterns.md`, `performance.md`, `security.md`, `testing.md`
+
+Overrides in effect:
+
+- TypeScript/web testing and coding-style guidance override common defaults where overlapping.

--- a/docs/solutions/architecture/2026-04-30-dual-intent-conversion-pattern.md
+++ b/docs/solutions/architecture/2026-04-30-dual-intent-conversion-pattern.md
@@ -1,0 +1,49 @@
+---
+title: Dual-intent conversion pattern for hiring + contract audiences
+category: architecture
+severity: medium
+tags:
+  [
+    'dual-intent',
+    'cta hierarchy',
+    'contact form',
+    'intent routing',
+    'anonymized case study',
+    'sveltekit'
+  ]
+applies_when:
+  - Personal/professional site must serve full-time hiring and contract leads simultaneously
+  - Public portfolio evidence is limited due to confidentiality
+  - Contact form is primary conversion surface
+---
+
+# Problem
+
+A single-site narrative was too generic for two distinct audiences (hiring managers and contract buyers), reducing clarity and lead quality.
+
+# Context
+
+The site needed equal priority for full-time and contract opportunities, while most impactful work could only be shared in anonymized form.
+
+# Solution
+
+Apply a dual-intent architecture:
+
+- Hero copy explicitly names both intents
+- CTA hierarchy is fixed: contact form (primary) → direct email (secondary) → résumé (supporting)
+- Contact backend derives inquiry intent from project type and prefixes email subject (`[Consulting]`, `[Contract]`, `[Full-Time]`)
+- Work page includes confidentiality-safe anonymized case studies with required structured fields
+- Homepage includes interactive proof module to increase credibility signal
+
+# Why this works
+
+It separates audience intent early without fragmenting the brand, captures higher-quality inbound context, and adds trust signals despite limited public artifacts.
+
+# Prevention
+
+For future site changes:
+
+- Preserve CTA order unless conversion data proves a better sequence
+- Keep intent-routing tests for contact subjects
+- Require anonymized case-study schema fields before publishing
+- Enforce RED→GREEN tests for copy/interaction changes that affect conversion paths

--- a/src/components/hero-dual-intent.test.ts
+++ b/src/components/hero-dual-intent.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("hero dual intent messaging", () => {
+	const heroPath = resolve("src/components/hero-section.svelte");
+	const hero = readFileSync(heroPath, "utf8");
+
+	it("includes explicit full-time and contract audience language", () => {
+		expect(hero).toContain("full-time");
+		expect(hero).toContain("contract");
+		expect(hero).toContain("Hiring manager");
+		expect(hero).toContain("Need contract help");
+	});
+
+	it("keeps contact as primary CTA ahead of secondary options", () => {
+		const contactIndex = hero.indexOf("Start a conversation");
+		const hireIndex = hero.indexOf("See hiring fit");
+		const resumeIndex = hero.indexOf("Download résumé");
+
+		expect(contactIndex).toBeGreaterThan(-1);
+		expect(hireIndex).toBeGreaterThan(-1);
+		expect(resumeIndex).toBeGreaterThan(-1);
+		expect(contactIndex).toBeLessThan(hireIndex);
+		expect(hireIndex).toBeLessThan(resumeIndex);
+	});
+});

--- a/src/components/hero-dual-intent.test.ts
+++ b/src/components/hero-dual-intent.test.ts
@@ -1,22 +1,22 @@
-import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-describe("hero dual intent messaging", () => {
-	const heroPath = resolve("src/components/hero-section.svelte");
-	const hero = readFileSync(heroPath, "utf8");
+describe('hero dual intent messaging', () => {
+	const heroPath = resolve('src/components/hero-section.svelte');
+	const hero = readFileSync(heroPath, 'utf8');
 
-	it("includes explicit full-time and contract audience language", () => {
-		expect(hero).toContain("full-time");
-		expect(hero).toContain("contract");
-		expect(hero).toContain("Hiring manager");
-		expect(hero).toContain("Need contract help");
+	it('includes explicit full-time and contract audience language', () => {
+		expect(hero).toContain('full-time');
+		expect(hero).toContain('contract');
+		expect(hero).toContain('Hiring manager');
+		expect(hero).toContain('Need contract help');
 	});
 
-	it("keeps contact as primary CTA ahead of secondary options", () => {
-		const contactIndex = hero.indexOf("Start a conversation");
-		const hireIndex = hero.indexOf("See hiring fit");
-		const resumeIndex = hero.indexOf("Download résumé");
+	it('keeps contact as primary CTA ahead of secondary options', () => {
+		const contactIndex = hero.indexOf('Start a conversation');
+		const hireIndex = hero.indexOf('See hiring fit');
+		const resumeIndex = hero.indexOf('Download résumé');
 
 		expect(contactIndex).toBeGreaterThan(-1);
 		expect(hireIndex).toBeGreaterThan(-1);

--- a/src/components/hero-section.svelte
+++ b/src/components/hero-section.svelte
@@ -15,8 +15,11 @@
 	<p class="hero-subtitle font-mono" role="doc-subtitle">SENIOR SOFTWARE ENGINEER</p>
 	<p class="body-text">
 		Companies hire me when they need a senior engineer — I join the team, learn the codebase, and
-		start delivering. Full-stack, backend-leaning, ten-plus years across fintech, healthcare, and
-		enterprise.
+		start delivering. Available for full-time leadership tracks and contract execution support.
+	</p>
+	<p class="audience-line">
+		<span>Hiring manager? I can slot in as a senior IC/tech lead.</span>
+		<span>Need contract help? I can embed fast and ship with your team.</span>
 	</p>
 	<div class="hero-stats mt-4 mb-2">
 		<div class="stats-numbers">
@@ -39,16 +42,23 @@
 		<a
 			href="/contact"
 			class="btn-primary text-center"
-			onclick={() => trackCTA('Get In Touch', 'home-hero-primary')}
+			onclick={() => trackCTA('Start a conversation', 'home-hero-primary')}
 		>
-			Get In Touch
+			Start a conversation
 		</a>
 		<a
 			href="/hire"
 			class="btn-secondary text-center"
-			onclick={() => trackCTA('See How I Work', 'home-hero-secondary')}
+			onclick={() => trackCTA('See hiring fit', 'home-hero-secondary')}
 		>
-			See How I Work
+			See hiring fit
+		</a>
+		<a
+			href="/adam_robinson.pdf"
+			class="btn-secondary text-center"
+			onclick={() => trackCTA('Download résumé', 'home-hero-secondary')}
+		>
+			Download résumé
 		</a>
 	</div>
 </section>
@@ -129,6 +139,14 @@
 	}
 
 	.industry-tag {
+		color: var(--color-muted);
+	}
+
+	.audience-line {
+		display: grid;
+		gap: 0.5rem;
+		margin-top: 0.75rem;
+		font-size: 0.9rem;
 		color: var(--color-muted);
 	}
 </style>

--- a/src/components/outcome-proof-interactions.test.ts
+++ b/src/components/outcome-proof-interactions.test.ts
@@ -1,21 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-describe("outcome proof interactions", () => {
-	const file = readFileSync(
-		resolve("src/components/outcome-proof.svelte"),
-		"utf8",
-	);
+describe('outcome proof interactions', () => {
+	const file = readFileSync(resolve('src/components/outcome-proof.svelte'), 'utf8');
 
-	it("renders interactive timeline tab buttons", () => {
+	it('renders interactive timeline tab buttons', () => {
 		expect(file).toContain('role="tablist"');
 		expect(file).toContain('role="tab"');
-		expect(file).toContain("aria-selected");
+		expect(file).toContain('aria-selected');
 	});
 
-	it("renders panel with reduced-motion safe interaction state", () => {
+	it('renders panel with reduced-motion safe interaction state', () => {
 		expect(file).toContain('role="tabpanel"');
-		expect(file).toContain("prefers-reduced-motion");
+		expect(file).toContain('prefers-reduced-motion');
 	});
 });

--- a/src/components/outcome-proof-interactions.test.ts
+++ b/src/components/outcome-proof-interactions.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("outcome proof interactions", () => {
+	const file = readFileSync(
+		resolve("src/components/outcome-proof.svelte"),
+		"utf8",
+	);
+
+	it("renders interactive timeline tab buttons", () => {
+		expect(file).toContain('role="tablist"');
+		expect(file).toContain('role="tab"');
+		expect(file).toContain("aria-selected");
+	});
+
+	it("renders panel with reduced-motion safe interaction state", () => {
+		expect(file).toContain('role="tabpanel"');
+		expect(file).toContain("prefers-reduced-motion");
+	});
+});

--- a/src/components/outcome-proof.svelte
+++ b/src/components/outcome-proof.svelte
@@ -1,52 +1,139 @@
 <script lang="ts">
 	import { outcomeProofPoints } from '$lib/copy';
+
+	let activeIndex = $state(0);
+	let reduceMotion = $state(false);
+
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+	});
+
+	function activate(index: number) {
+		activeIndex = index;
+	}
+
+	const activePoint = $derived(outcomeProofPoints[activeIndex]);
 </script>
 
 <section aria-labelledby="outcomes-heading" class="py-10 section-border">
 	<h2 id="outcomes-heading" class="section-heading mb-6">
-		Recent outcomes
+		Outcome timeline
 		<span class="accent-dot" aria-hidden="true">.</span>
 	</h2>
-	<ul class="outcome-list" aria-label="Recent delivery outcomes">
-		{#each outcomeProofPoints as point (point.headline)}
-			<li class="outcome-item">
-				<a href={point.href} class="outcome-headline link-underline">{point.headline}</a>
-				<p class="outcome-detail">{point.detail}</p>
-			</li>
-		{/each}
-	</ul>
+
+	<div class="outcomes-grid">
+		<div role="tablist" aria-label="Outcome timeline" class="timeline-list">
+			{#each outcomeProofPoints as point, index (point.headline)}
+				<button
+					id={`timeline-tab-${index}`}
+					role="tab"
+					type="button"
+					class="timeline-tab"
+					class:is-active={index === activeIndex}
+					aria-selected={index === activeIndex}
+					aria-controls={`timeline-panel-${index}`}
+					onclick={() => activate(index)}
+				>
+					<span class="timeline-dot" aria-hidden="true"></span>
+					<span>{point.headline}</span>
+				</button>
+			{/each}
+		</div>
+
+		<div
+			id={`timeline-panel-${activeIndex}`}
+			role="tabpanel"
+			aria-labelledby={`timeline-tab-${activeIndex}`}
+			class="timeline-panel"
+			class:reduced-motion={reduceMotion}
+		>
+			<h3 class="panel-title">{activePoint.headline}</h3>
+			<p class="panel-detail">{activePoint.detail}</p>
+			<a href={activePoint.href} class="panel-link link-underline">Read related work →</a>
+		</div>
+	</div>
 </section>
 
 <style>
-	.outcome-list {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-		display: flex;
-		flex-direction: column;
-		gap: 0;
+	.outcomes-grid {
+		display: grid;
+		gap: 1rem;
 	}
 
-	.outcome-item {
-		padding: 0.75rem 0;
+	.timeline-list {
+		display: grid;
+		gap: 0.5rem;
+	}
+
+	.timeline-tab {
+		display: flex;
+		align-items: baseline;
+		gap: 0.55rem;
+		width: 100%;
+		text-align: left;
+		padding: 0.5rem 0;
+		border: none;
+		background: transparent;
+		color: var(--color-muted);
+		cursor: pointer;
 		border-bottom: 1px solid var(--color-border);
 	}
 
-	.outcome-item:first-child {
+	.timeline-tab:first-child {
 		border-top: 1px solid var(--color-border);
 	}
 
-	.outcome-headline {
-		font-size: 0.92rem;
-		font-weight: 500;
+	.timeline-dot {
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--color-accent) 30%, transparent);
+		flex-shrink: 0;
+	}
+
+	.timeline-tab.is-active {
+		color: var(--color-text);
+	}
+
+	.timeline-tab.is-active .timeline-dot {
+		background: var(--color-accent);
+	}
+
+	.timeline-panel {
+		border: 1px solid var(--color-border);
+		border-radius: 4px;
+		padding: 0.9rem;
+		background: color-mix(in srgb, var(--color-accent) 5%, var(--color-bg));
+		transition: transform 180ms ease;
+	}
+
+	.timeline-panel:not(.reduced-motion) {
+		transform: translateY(-1px);
+	}
+
+	.panel-title {
+		font-size: 1rem;
+		margin: 0 0 0.45rem 0;
+	}
+
+	.panel-detail {
+		font-size: 0.88rem;
+		line-height: 1.6;
+		color: var(--color-muted);
+		margin: 0 0 0.7rem 0;
+	}
+
+	.panel-link {
+		font-size: 0.82rem;
 		color: var(--color-text);
 		text-decoration: none;
 	}
 
-	.outcome-detail {
-		font-size: 0.85rem;
-		line-height: 1.6;
-		color: var(--color-muted);
-		margin-top: 0.35rem;
+	@media (min-width: 860px) {
+		.outcomes-grid {
+			grid-template-columns: 1fr 1fr;
+			align-items: start;
+		}
 	}
 </style>

--- a/src/components/recently-shipped.svelte
+++ b/src/components/recently-shipped.svelte
@@ -4,7 +4,7 @@
 
 <section aria-labelledby="recent-heading" class="py-10 section-border">
 	<h2 id="recent-heading" class="section-heading mb-6">
-		Recently shipped
+		Recent signals
 		<span class="accent-dot" aria-hidden="true">.</span>
 	</h2>
 	<ul class="recent-list" aria-label="Recently shipped work and writing">

--- a/src/content/case-studies/internal-platform-translation-and-throughput.md
+++ b/src/content/case-studies/internal-platform-translation-and-throughput.md
@@ -1,0 +1,8 @@
+---
+title: 'Internal Platform: Translation + Throughput'
+audience: 'Hiring managers and platform teams'
+confidentiality: 'anonymized'
+situation: 'A high-volume internal workflow had fragmented localization and manual-heavy processing that slowed releases and increased operational risk.'
+approach: 'Introduced a unified localization flow for static and dynamic content, then designed a service boundary for bulk operations to reduce repetitive handling and improve consistency.'
+outcome: 'Release confidence improved, high-volume operations became predictable, and the team gained a reusable pattern for similar workflows.'
+---

--- a/src/content/case-studies/legacy-publishing-modernization.md
+++ b/src/content/case-studies/legacy-publishing-modernization.md
@@ -1,0 +1,8 @@
+---
+title: 'Legacy Publishing Modernization'
+audience: 'Product and engineering leadership'
+confidentiality: 'anonymized'
+situation: 'A content platform depended on aging tooling that created long publishing cycles and made cross-team coordination brittle.'
+approach: 'Led a phased modernization with a new publishing model, safer rollout checkpoints, and clearer ownership boundaries across product and engineering.'
+outcome: 'Time-to-publish dropped materially, release quality stabilized, and the modernization unlocked follow-on roadmap work.'
+---

--- a/src/lib/server/anonymized-case-study-schema.test.ts
+++ b/src/lib/server/anonymized-case-study-schema.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { getAnonymizedCaseStudies } from "./caseStudies";
+
+describe("anonymized case study schema", () => {
+	it("returns studies with required fields", () => {
+		const studies = getAnonymizedCaseStudies();
+
+		expect(studies.length).toBeGreaterThanOrEqual(1);
+		for (const study of studies) {
+			expect(study.slug.length).toBeGreaterThan(0);
+			expect(study.title.length).toBeGreaterThan(0);
+			expect(study.audience.length).toBeGreaterThan(0);
+			expect(study.confidentiality).toBe("anonymized");
+			expect(study.situation.length).toBeGreaterThan(0);
+			expect(study.approach.length).toBeGreaterThan(0);
+			expect(study.outcome.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/src/lib/server/anonymized-case-study-schema.test.ts
+++ b/src/lib/server/anonymized-case-study-schema.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { getAnonymizedCaseStudies } from "./caseStudies";
+import { describe, expect, it } from 'vitest';
+import { getAnonymizedCaseStudies } from './caseStudies';
 
-describe("anonymized case study schema", () => {
-	it("returns studies with required fields", () => {
+describe('anonymized case study schema', () => {
+	it('returns studies with required fields', () => {
 		const studies = getAnonymizedCaseStudies();
 
 		expect(studies.length).toBeGreaterThanOrEqual(1);
@@ -10,7 +10,7 @@ describe("anonymized case study schema", () => {
 			expect(study.slug.length).toBeGreaterThan(0);
 			expect(study.title.length).toBeGreaterThan(0);
 			expect(study.audience.length).toBeGreaterThan(0);
-			expect(study.confidentiality).toBe("anonymized");
+			expect(study.confidentiality).toBe('anonymized');
 			expect(study.situation.length).toBeGreaterThan(0);
 			expect(study.approach.length).toBeGreaterThan(0);
 			expect(study.outcome.length).toBeGreaterThan(0);

--- a/src/lib/server/caseStudies.ts
+++ b/src/lib/server/caseStudies.ts
@@ -1,0 +1,51 @@
+import matter from "gray-matter";
+
+export type AnonymizedCaseStudy = {
+	slug: string;
+	title: string;
+	audience: string;
+	confidentiality: "anonymized";
+	situation: string;
+	approach: string;
+	outcome: string;
+};
+
+const caseStudyRaw = import.meta.glob("/src/content/case-studies/*.md", {
+	query: "?raw",
+	import: "default",
+	eager: true,
+});
+
+export function getAnonymizedCaseStudies(): AnonymizedCaseStudy[] {
+	const studies: AnonymizedCaseStudy[] = [];
+
+	for (const [filepath, raw] of Object.entries(caseStudyRaw)) {
+		const filename = filepath.split("/").pop();
+		if (!filename) continue;
+
+		const slug = filename.replace(/\.md$/, "");
+		const { data } = matter(raw as string);
+		if (
+			!data.title ||
+			!data.audience ||
+			!data.situation ||
+			!data.approach ||
+			!data.outcome ||
+			data.confidentiality !== "anonymized"
+		) {
+			continue;
+		}
+
+		studies.push({
+			slug,
+			title: data.title,
+			audience: data.audience,
+			confidentiality: "anonymized",
+			situation: data.situation,
+			approach: data.approach,
+			outcome: data.outcome,
+		});
+	}
+
+	return studies;
+}

--- a/src/lib/server/caseStudies.ts
+++ b/src/lib/server/caseStudies.ts
@@ -1,29 +1,29 @@
-import matter from "gray-matter";
+import matter from 'gray-matter';
 
 export type AnonymizedCaseStudy = {
 	slug: string;
 	title: string;
 	audience: string;
-	confidentiality: "anonymized";
+	confidentiality: 'anonymized';
 	situation: string;
 	approach: string;
 	outcome: string;
 };
 
-const caseStudyRaw = import.meta.glob("/src/content/case-studies/*.md", {
-	query: "?raw",
-	import: "default",
-	eager: true,
+const caseStudyRaw = import.meta.glob('/src/content/case-studies/*.md', {
+	query: '?raw',
+	import: 'default',
+	eager: true
 });
 
 export function getAnonymizedCaseStudies(): AnonymizedCaseStudy[] {
 	const studies: AnonymizedCaseStudy[] = [];
 
 	for (const [filepath, raw] of Object.entries(caseStudyRaw)) {
-		const filename = filepath.split("/").pop();
+		const filename = filepath.split('/').pop();
 		if (!filename) continue;
 
-		const slug = filename.replace(/\.md$/, "");
+		const slug = filename.replace(/\.md$/, '');
 		const { data } = matter(raw as string);
 		if (
 			!data.title ||
@@ -31,7 +31,7 @@ export function getAnonymizedCaseStudies(): AnonymizedCaseStudy[] {
 			!data.situation ||
 			!data.approach ||
 			!data.outcome ||
-			data.confidentiality !== "anonymized"
+			data.confidentiality !== 'anonymized'
 		) {
 			continue;
 		}
@@ -40,10 +40,10 @@ export function getAnonymizedCaseStudies(): AnonymizedCaseStudy[] {
 			slug,
 			title: data.title,
 			audience: data.audience,
-			confidentiality: "anonymized",
+			confidentiality: 'anonymized',
 			situation: data.situation,
 			approach: data.approach,
-			outcome: data.outcome,
+			outcome: data.outcome
 		});
 	}
 

--- a/src/lib/server/contact-intent-routing.test.ts
+++ b/src/lib/server/contact-intent-routing.test.ts
@@ -1,26 +1,26 @@
-import { describe, expect, it } from "vitest";
-import { formatInquirySubject, inferInquiryIntent } from "./contactEmail";
+import { describe, expect, it } from 'vitest';
+import { formatInquirySubject, inferInquiryIntent } from './contactEmail';
 
-describe("contact intent routing", () => {
-	it("detects full-time intent", () => {
-		expect(inferInquiryIntent("Full-time opportunity")).toBe("full-time");
+describe('contact intent routing', () => {
+	it('detects full-time intent', () => {
+		expect(inferInquiryIntent('Full-time opportunity')).toBe('full-time');
 	});
 
-	it("detects contract intent", () => {
-		expect(inferInquiryIntent("Contract / Freelance project")).toBe("contract");
+	it('detects contract intent', () => {
+		expect(inferInquiryIntent('Contract / Freelance project')).toBe('contract');
 	});
 
-	it("detects consulting intent", () => {
-		expect(inferInquiryIntent("Technical consulting")).toBe("consulting");
+	it('detects consulting intent', () => {
+		expect(inferInquiryIntent('Technical consulting')).toBe('consulting');
 	});
 
-	it("falls back to general intent", () => {
-		expect(inferInquiryIntent("Something else")).toBe("general");
+	it('falls back to general intent', () => {
+		expect(inferInquiryIntent('Something else')).toBe('general');
 	});
 
-	it("formats subject with intent label and sender name", () => {
-		expect(formatInquirySubject("Ada Lovelace", "Technical consulting")).toBe(
-			"[Consulting] New inquiry from Ada Lovelace",
+	it('formats subject with intent label and sender name', () => {
+		expect(formatInquirySubject('Ada Lovelace', 'Technical consulting')).toBe(
+			'[Consulting] New inquiry from Ada Lovelace'
 		);
 	});
 });

--- a/src/lib/server/contact-intent-routing.test.ts
+++ b/src/lib/server/contact-intent-routing.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { formatInquirySubject, inferInquiryIntent } from "./contactEmail";
+
+describe("contact intent routing", () => {
+	it("detects full-time intent", () => {
+		expect(inferInquiryIntent("Full-time opportunity")).toBe("full-time");
+	});
+
+	it("detects contract intent", () => {
+		expect(inferInquiryIntent("Contract / Freelance project")).toBe("contract");
+	});
+
+	it("detects consulting intent", () => {
+		expect(inferInquiryIntent("Technical consulting")).toBe("consulting");
+	});
+
+	it("falls back to general intent", () => {
+		expect(inferInquiryIntent("Something else")).toBe("general");
+	});
+
+	it("formats subject with intent label and sender name", () => {
+		expect(formatInquirySubject("Ada Lovelace", "Technical consulting")).toBe(
+			"[Consulting] New inquiry from Ada Lovelace",
+		);
+	});
+});

--- a/src/lib/server/contactEmail.ts
+++ b/src/lib/server/contactEmail.ts
@@ -1,43 +1,73 @@
-import { Resend } from 'resend';
-import { dev } from '$app/environment';
-import { env } from '$env/dynamic/private';
-import { getRedis } from '$lib/server/redis';
-import { EMAIL } from '$lib/constants';
-import type { ContactFormData } from '$lib/validation';
-import { contactNotificationHtml } from '$lib/server/emailTemplates';
+import { Resend } from "resend";
+import { dev } from "$app/environment";
+import { env } from "$env/dynamic/private";
+import { getRedis } from "$lib/server/redis";
+import { EMAIL } from "$lib/constants";
+import type { ContactFormData } from "$lib/validation";
+import { contactNotificationHtml } from "$lib/server/emailTemplates";
+
+export type InquiryIntent = "full-time" | "contract" | "consulting" | "general";
+
+export function inferInquiryIntent(projectType: string): InquiryIntent {
+	const value = projectType.trim().toLowerCase();
+
+	if (value.includes("full-time")) return "full-time";
+	if (value.includes("contract") || value.includes("freelance"))
+		return "contract";
+	if (value.includes("consulting")) return "consulting";
+
+	return "general";
+}
+
+export function formatInquirySubject(
+	name: string,
+	projectType: string,
+): string {
+	const intent = inferInquiryIntent(projectType);
+	const labelMap: Record<InquiryIntent, string> = {
+		"full-time": "Full-Time",
+		contract: "Contract",
+		consulting: "Consulting",
+		general: "General",
+	};
+
+	return `[${labelMap[intent]}] New inquiry from ${name}`;
+}
 
 export async function sendContactNotification(
 	data: ContactFormData,
-	subject: string
+	subject: string,
 ): Promise<void> {
 	if (!env.RESEND_API_KEY) {
 		if (dev) {
-			console.log('📧 RESEND_API_KEY not configured — email notification skipped');
-			console.log('📧 Email would send:', { subject, to: EMAIL });
+			console.log(
+				"📧 RESEND_API_KEY not configured — email notification skipped",
+			);
+			console.log("📧 Email would send:", { subject, to: EMAIL });
 			return;
 		}
-		throw new Error('RESEND_API_KEY is not configured');
+		throw new Error("RESEND_API_KEY is not configured");
 	}
 
 	const resend = new Resend(env.RESEND_API_KEY);
 	await resend.emails.send({
-		from: 'contact@adamrobinson.tech',
+		from: "contact@adamrobinson.tech",
 		to: EMAIL,
 		subject,
-		html: contactNotificationHtml(data)
+		html: contactNotificationHtml(data),
 	});
 
-	console.log('📧 Email sent successfully via Resend');
+	console.log("📧 Email sent successfully via Resend");
 }
 
 export async function logFailedSubmission(
 	data: ContactFormData,
 	body: string,
-	ip: string
+	ip: string,
 ): Promise<boolean> {
 	const redis = getRedis();
 	try {
-		if (!redis) throw new Error('Redis unavailable');
+		if (!redis) throw new Error("Redis unavailable");
 		const key = `failed_contact:${Date.now()}:${ip}`;
 		await redis.set(
 			key,
@@ -48,15 +78,18 @@ export async function logFailedSubmission(
 				timeline: data.timeline,
 				budget: data.budget,
 				body,
-				ip
+				ip,
 			}),
-			{ ex: 30 * 24 * 60 * 60 }
+			{ ex: 30 * 24 * 60 * 60 },
 		);
 		console.log(`📧 Failed submission logged to Redis under key: ${key}`);
 		return true;
 	} catch (redisError) {
-		console.error('📧 Redis logging also failed — submission may be lost:', redisError);
-		console.log('📧 Submission data:', { name: data.name, email: data.email });
+		console.error(
+			"📧 Redis logging also failed — submission may be lost:",
+			redisError,
+		);
+		console.log("📧 Submission data:", { name: data.name, email: data.email });
 		return false;
 	}
 }

--- a/src/lib/server/contactEmail.ts
+++ b/src/lib/server/contactEmail.ts
@@ -1,34 +1,30 @@
-import { Resend } from "resend";
-import { dev } from "$app/environment";
-import { env } from "$env/dynamic/private";
-import { getRedis } from "$lib/server/redis";
-import { EMAIL } from "$lib/constants";
-import type { ContactFormData } from "$lib/validation";
-import { contactNotificationHtml } from "$lib/server/emailTemplates";
+import { Resend } from 'resend';
+import { dev } from '$app/environment';
+import { env } from '$env/dynamic/private';
+import { getRedis } from '$lib/server/redis';
+import { EMAIL } from '$lib/constants';
+import type { ContactFormData } from '$lib/validation';
+import { contactNotificationHtml } from '$lib/server/emailTemplates';
 
-export type InquiryIntent = "full-time" | "contract" | "consulting" | "general";
+export type InquiryIntent = 'full-time' | 'contract' | 'consulting' | 'general';
 
 export function inferInquiryIntent(projectType: string): InquiryIntent {
 	const value = projectType.trim().toLowerCase();
 
-	if (value.includes("full-time")) return "full-time";
-	if (value.includes("contract") || value.includes("freelance"))
-		return "contract";
-	if (value.includes("consulting")) return "consulting";
+	if (value.includes('full-time')) return 'full-time';
+	if (value.includes('contract') || value.includes('freelance')) return 'contract';
+	if (value.includes('consulting')) return 'consulting';
 
-	return "general";
+	return 'general';
 }
 
-export function formatInquirySubject(
-	name: string,
-	projectType: string,
-): string {
+export function formatInquirySubject(name: string, projectType: string): string {
 	const intent = inferInquiryIntent(projectType);
 	const labelMap: Record<InquiryIntent, string> = {
-		"full-time": "Full-Time",
-		contract: "Contract",
-		consulting: "Consulting",
-		general: "General",
+		'full-time': 'Full-Time',
+		contract: 'Contract',
+		consulting: 'Consulting',
+		general: 'General'
 	};
 
 	return `[${labelMap[intent]}] New inquiry from ${name}`;
@@ -36,38 +32,36 @@ export function formatInquirySubject(
 
 export async function sendContactNotification(
 	data: ContactFormData,
-	subject: string,
+	subject: string
 ): Promise<void> {
 	if (!env.RESEND_API_KEY) {
 		if (dev) {
-			console.log(
-				"📧 RESEND_API_KEY not configured — email notification skipped",
-			);
-			console.log("📧 Email would send:", { subject, to: EMAIL });
+			console.log('📧 RESEND_API_KEY not configured — email notification skipped');
+			console.log('📧 Email would send:', { subject, to: EMAIL });
 			return;
 		}
-		throw new Error("RESEND_API_KEY is not configured");
+		throw new Error('RESEND_API_KEY is not configured');
 	}
 
 	const resend = new Resend(env.RESEND_API_KEY);
 	await resend.emails.send({
-		from: "contact@adamrobinson.tech",
+		from: 'contact@adamrobinson.tech',
 		to: EMAIL,
 		subject,
-		html: contactNotificationHtml(data),
+		html: contactNotificationHtml(data)
 	});
 
-	console.log("📧 Email sent successfully via Resend");
+	console.log('📧 Email sent successfully via Resend');
 }
 
 export async function logFailedSubmission(
 	data: ContactFormData,
 	body: string,
-	ip: string,
+	ip: string
 ): Promise<boolean> {
 	const redis = getRedis();
 	try {
-		if (!redis) throw new Error("Redis unavailable");
+		if (!redis) throw new Error('Redis unavailable');
 		const key = `failed_contact:${Date.now()}:${ip}`;
 		await redis.set(
 			key,
@@ -78,18 +72,15 @@ export async function logFailedSubmission(
 				timeline: data.timeline,
 				budget: data.budget,
 				body,
-				ip,
+				ip
 			}),
-			{ ex: 30 * 24 * 60 * 60 },
+			{ ex: 30 * 24 * 60 * 60 }
 		);
 		console.log(`📧 Failed submission logged to Redis under key: ${key}`);
 		return true;
 	} catch (redisError) {
-		console.error(
-			"📧 Redis logging also failed — submission may be lost:",
-			redisError,
-		);
-		console.log("📧 Submission data:", { name: data.name, email: data.email });
+		console.error('📧 Redis logging also failed — submission may be lost:', redisError);
+		console.log('📧 Submission data:', { name: data.name, email: data.email });
 		return false;
 	}
 }

--- a/src/lib/stores/severance.ts
+++ b/src/lib/stores/severance.ts
@@ -1,23 +1,23 @@
-export type SeveranceMode = "outie" | "innie";
+export type SeveranceMode = 'outie' | 'innie';
 
-const STORAGE_KEY = "severance-mode";
-const UNLOCK_KEY = "severed-unlocked";
+const STORAGE_KEY = 'severance-mode';
+const UNLOCK_KEY = 'severed-unlocked';
 
-let mode: SeveranceMode = "outie";
+let mode: SeveranceMode = 'outie';
 let unlocked = false;
 
 function applyModeToDom(value: SeveranceMode) {
-	if (typeof document === "undefined") return;
-	document.documentElement.setAttribute("data-severance", value);
+	if (typeof document === 'undefined') return;
+	document.documentElement.setAttribute('data-severance', value);
 }
 
 export function initSeveranceMode() {
-	if (typeof window === "undefined") return;
+	if (typeof window === 'undefined') return;
 	const saved = window.localStorage.getItem(STORAGE_KEY);
-	if (saved === "innie" || saved === "outie") {
+	if (saved === 'innie' || saved === 'outie') {
 		mode = saved;
 	}
-	unlocked = window.localStorage.getItem(UNLOCK_KEY) === "true";
+	unlocked = window.localStorage.getItem(UNLOCK_KEY) === 'true';
 	applyModeToDom(mode);
 }
 
@@ -27,7 +27,7 @@ export function getSeveranceMode() {
 
 export function setSeveranceMode(value: SeveranceMode) {
 	mode = value;
-	if (typeof window !== "undefined") {
+	if (typeof window !== 'undefined') {
 		window.localStorage.setItem(STORAGE_KEY, value);
 	}
 	applyModeToDom(value);
@@ -35,8 +35,8 @@ export function setSeveranceMode(value: SeveranceMode) {
 
 export function unlockSeveredRoute() {
 	unlocked = true;
-	if (typeof window !== "undefined") {
-		window.localStorage.setItem(UNLOCK_KEY, "true");
+	if (typeof window !== 'undefined') {
+		window.localStorage.setItem(UNLOCK_KEY, 'true');
 	}
 }
 

--- a/src/lib/terminal-commands.ts
+++ b/src/lib/terminal-commands.ts
@@ -1,7 +1,7 @@
-import { techStack } from "$lib/copy";
-import { EMAIL, GITHUB_USERNAME, LINKEDIN_HANDLE } from "$lib/constants";
+import { techStack } from '$lib/copy';
+import { EMAIL, GITHUB_USERNAME, LINKEDIN_HANDLE } from '$lib/constants';
 
-export type Mode = "terminal" | "rpg" | "innie";
+export type Mode = 'terminal' | 'rpg' | 'innie';
 
 export type CommandResult = {
 	lines: string[];
@@ -22,20 +22,20 @@ type CommandDef = {
 const allStack = techStack.flatMap((g) => g.items);
 
 const INCANTATIONS: Record<string, string> = {
-	"ex codice lumen": "from code, light",
+	'ex codice lumen': 'from code, light'
 };
 
 export function normalize(lower: string): string {
-	if (lower === "-h" || lower === "--help") return "help";
-	if (lower === "ls /") return "ls";
-	if (lower === "ls work") return "ls /work";
-	if (lower === "ls stack") return "ls /stack";
-	if (lower === "open hire") return "open /hire";
-	if (lower === "quit") return "exit";
-	if (lower === "rm -rf /" || lower === "rm -rf ~") return "rm -rf .";
-	if (lower === "vi" || lower === "nano" || lower === "emacs") return "vim";
-	if (lower === "hyrule") return "zelda";
-	if (lower === "outie mode") return "outie";
+	if (lower === '-h' || lower === '--help') return 'help';
+	if (lower === 'ls /') return 'ls';
+	if (lower === 'ls work') return 'ls /work';
+	if (lower === 'ls stack') return 'ls /stack';
+	if (lower === 'open hire') return 'open /hire';
+	if (lower === 'quit') return 'exit';
+	if (lower === 'rm -rf /' || lower === 'rm -rf ~') return 'rm -rf .';
+	if (lower === 'vi' || lower === 'nano' || lower === 'emacs') return 'vim';
+	if (lower === 'hyrule') return 'zelda';
+	if (lower === 'outie mode') return 'outie';
 	if (lower in INCANTATIONS) return `translate ${lower}`;
 	return lower;
 }
@@ -44,170 +44,165 @@ const commands: Record<string, CommandDef> = {
 	whoami: {
 		terminal: {
 			lines: [
-				"adam robinson",
-				"lead software engineer · 10+ years",
-				"currently: staff aug at icapital (fintech)",
-				"past: healthcasts · angi · shell",
-				"",
-				"type 'help' for available commands.",
-			],
+				'adam robinson',
+				'lead software engineer · 10+ years',
+				'currently: staff aug at icapital (fintech)',
+				'past: healthcasts · angi · shell',
+				'',
+				"type 'help' for available commands."
+			]
 		},
 		rpg: {
 			lines: [
-				"┌─────────────────────────────────────┐",
-				"│  ADAM ROBINSON                      │",
-				"│  JOB CLASS: Lead Engineer    LV 10  │",
-				"│  HP: ████████████  MP: ████████░░   │",
-				"│                                     │",
-				"│  A wandering engineer of ten years. │",
-				"│  Backend-leaning. Ships clean code. │",
-				"│  Currently embedded at iCapital.    │",
-				"└─────────────────────────────────────┘",
-			],
-		},
+				'┌─────────────────────────────────────┐',
+				'│  ADAM ROBINSON                      │',
+				'│  JOB CLASS: Lead Engineer    LV 10  │',
+				'│  HP: ████████████  MP: ████████░░   │',
+				'│                                     │',
+				'│  A wandering engineer of ten years. │',
+				'│  Backend-leaning. Ships clean code. │',
+				'│  Currently embedded at iCapital.    │',
+				'└─────────────────────────────────────┘'
+			]
+		}
 	},
 
 	help: {
 		terminal: {
 			lines: [
-				"available commands:",
-				"",
-				"  whoami          who is this person",
-				"  innie           enter severance mode",
-				"  outie           return to normal mode",
-				"  ls              list directories",
-				"  ls /work        list projects",
-				"  ls /stack       list tech stack",
-				"  cat resume.txt  print resume",
-				"  contact         contact information",
-				"  open /hire      open the hire page",
-				"  echo $STACK     print tech stack",
-				"  git log         recent commit history",
-				"  ritual          reveal arcane easter eggs",
-				"  summon          list summonable endpoints",
-				"  severed         open the severed floor",
-				"  translate <incantation>  decode an incantation",
-				"  clear           clear the terminal",
-				"  exit            close the terminal",
-			],
+				'available commands:',
+				'',
+				'  whoami          who is this person',
+				'  innie           enter severance mode',
+				'  outie           return to normal mode',
+				'  ls              list directories',
+				'  ls /work        list projects',
+				'  ls /stack       list tech stack',
+				'  cat resume.txt  print resume',
+				'  contact         contact information',
+				'  open /hire      open the hire page',
+				'  echo $STACK     print tech stack',
+				'  git log         recent commit history',
+				'  ritual          reveal arcane easter eggs',
+				'  summon          list summonable endpoints',
+				'  severed         open the severed floor',
+				'  translate <incantation>  decode an incantation',
+				'  clear           clear the terminal',
+				'  exit            close the terminal'
+			]
 		},
 		rpg: {
 			lines: [
 				"⚔  ADVENTURER'S HANDBOOK",
-				"",
-				"  whoami          inspect your character",
-				"  ls /work        open the treasure chest",
-				"  ls /stack       survey your arsenal",
-				"  cat resume.txt  read the ancient scroll",
-				"  git log         consult the quest log",
-				"  sudo hire adam  recruit the wandering engineer",
-				"  contact         send a raven",
-				"  mode terminal   return to the real world",
-				"  clear           banish all text",
-				"  exit            close the portal",
-			],
-		},
+				'',
+				'  whoami          inspect your character',
+				'  ls /work        open the treasure chest',
+				'  ls /stack       survey your arsenal',
+				'  cat resume.txt  read the ancient scroll',
+				'  git log         consult the quest log',
+				'  sudo hire adam  recruit the wandering engineer',
+				'  contact         send a raven',
+				'  mode terminal   return to the real world',
+				'  clear           banish all text',
+				'  exit            close the portal'
+			]
+		}
 	},
 
 	innie: {
 		terminal: {
 			lines: [
-				"▣ LUMON TERMINAL ONLINE",
-				"the work is mysterious and important.",
-				"you are now in innie mode.",
+				'▣ LUMON TERMINAL ONLINE',
+				'the work is mysterious and important.',
+				'you are now in innie mode.'
 			],
-			modeChange: "innie",
-		},
+			modeChange: 'innie'
+		}
 	},
 
 	outie: {
 		terminal: {
-			lines: ["you are now in outie mode. welcome back."],
-			modeChange: "terminal",
+			lines: ['you are now in outie mode. welcome back.'],
+			modeChange: 'terminal'
 		},
 		rpg: {
-			lines: ["you are now in outie mode. welcome back."],
-			modeChange: "terminal",
+			lines: ['you are now in outie mode. welcome back.'],
+			modeChange: 'terminal'
 		},
 		innie: {
-			lines: ["you are now in outie mode. welcome back."],
-			modeChange: "terminal",
-		},
+			lines: ['you are now in outie mode. welcome back.'],
+			modeChange: 'terminal'
+		}
 	},
 
 	macrodata: {
 		terminal: {
-			lines: ["refining tempers: 98%", "numbers sorted. feelings unresolved."],
+			lines: ['refining tempers: 98%', 'numbers sorted. feelings unresolved.']
 		},
 		innie: {
-			lines: [
-				"refinement queue accepted.",
-				"the numbers are scary, as expected.",
-			],
-		},
+			lines: ['refinement queue accepted.', 'the numbers are scary, as expected.']
+		}
 	},
 
 	waffleparty: {
 		terminal: {
-			lines: [
-				"request denied by management. please enjoy a melon bar instead.",
-			],
+			lines: ['request denied by management. please enjoy a melon bar instead.']
 		},
 		innie: {
-			lines: ["special perk unlocked: one sanctioned waffle party."],
-		},
+			lines: ['special perk unlocked: one sanctioned waffle party.']
+		}
 	},
 
 	ls: {
-		terminal: { lines: ["work/   stack/   blog/   contact"] },
+		terminal: { lines: ['work/   stack/   blog/   contact'] }
 	},
 
-	"ls /work": {
-		terminal: { lines: ["icapital/   healthcasts/   angi/   shell/"] },
+	'ls /work': {
+		terminal: { lines: ['icapital/   healthcasts/   angi/   shell/'] },
 		rpg: {
 			lines: [
-				"You open the chest.",
-				"Inside you find:",
-				"",
-				"⚔  iCapital     — Fintech dungeon, still active",
-				"🏰  Healthcasts  — Legacy fortress, rebuilt from within",
+				'You open the chest.',
+				'Inside you find:',
+				'',
+				'⚔  iCapital     — Fintech dungeon, still active',
+				'🏰  Healthcasts  — Legacy fortress, rebuilt from within',
 				"🌋  Shell        — Oil platform at world's edge",
-				"🗺  Angi         — Three kingdoms, one ranger",
-			],
-		},
+				'🗺  Angi         — Three kingdoms, one ranger'
+			]
+		}
 	},
 
-	"ls /stack": {
+	'ls /stack': {
 		terminal: {
-			lines: ["frontend/   backend/   infrastructure/   tools/   ai/"],
-		},
+			lines: ['frontend/   backend/   infrastructure/   tools/   ai/']
+		}
 	},
 
-	"cat resume.txt": {
+	'cat resume.txt': {
 		terminal: {
 			lines: [
-				"Adam Robinson — Lead Software Engineer",
-				"════════════════════════════════════════",
-				"10+ years · full-stack, backend-leaning",
-				"",
-				"Current",
-				"  iCapital · Staff Aug / Lead Engineer · 2024–present",
-				"",
-				"Past",
-				"  Healthcasts · Team Lead · 2022–2024",
-				"  Angi · Staff Aug / Senior Engineer · 2021–2022",
-				"  Shell · Software Engineer · 2018–2019",
-				"",
-				"Stack",
-				"  React · TypeScript · Node.js · Elixir · Ruby on Rails",
-				"  AWS · Auth0 · PostgreSQL · Redis",
-				"",
-				"Contact",
+				'Adam Robinson — Lead Software Engineer',
+				'════════════════════════════════════════',
+				'10+ years · full-stack, backend-leaning',
+				'',
+				'Current',
+				'  iCapital · Staff Aug / Lead Engineer · 2024–present',
+				'',
+				'Past',
+				'  Healthcasts · Team Lead · 2022–2024',
+				'  Angi · Staff Aug / Senior Engineer · 2021–2022',
+				'  Shell · Software Engineer · 2018–2019',
+				'',
+				'Stack',
+				'  React · TypeScript · Node.js · Elixir · Ruby on Rails',
+				'  AWS · Auth0 · PostgreSQL · Redis',
+				'',
+				'Contact',
 				`  ${EMAIL}`,
 				`  github.com/${GITHUB_USERNAME}`,
-				"  adamrobinson.tech/hire",
-			],
-		},
+				'  adamrobinson.tech/hire'
+			]
+		}
 	},
 
 	contact: {
@@ -216,220 +211,220 @@ const commands: Record<string, CommandDef> = {
 				`email     ${EMAIL}`,
 				`github    github.com/${GITHUB_USERNAME}`,
 				`linkedin  linkedin.com/in/${LINKEDIN_HANDLE}`,
-				"hire      adamrobinson.tech/hire",
-			],
-		},
+				'hire      adamrobinson.tech/hire'
+			]
+		}
 	},
 
-	"open /hire": {
+	'open /hire': {
 		terminal: {
-			lines: ["opening /hire..."],
-			navigate: "/hire",
-			navigateDelay: 600,
-		},
+			lines: ['opening /hire...'],
+			navigate: '/hire',
+			navigateDelay: 600
+		}
 	},
 
-	"echo $stack": {
-		terminal: { lines: [allStack.join(", ")] },
+	'echo $stack': {
+		terminal: { lines: [allStack.join(', ')] }
 	},
 
-	"sudo hire adam": {
+	'sudo hire adam': {
 		terminal: {
 			lines: [
-				"[sudo] password for hiring_manager: ········",
-				"checking credentials...",
-				"permission granted.",
-				"redirecting to /contact...",
+				'[sudo] password for hiring_manager: ········',
+				'checking credentials...',
+				'permission granted.',
+				'redirecting to /contact...'
 			],
-			navigate: "/contact",
-			navigateDelay: 1500,
+			navigate: '/contact',
+			navigateDelay: 1500
 		},
 		rpg: {
 			lines: [
-				"❯ HIRE ADAM?",
-				"  ▶ YES",
-				"    NO",
-				"",
-				"...",
-				"",
-				"✨ Adam has joined the party!",
-				"redirecting to /contact...",
+				'❯ HIRE ADAM?',
+				'  ▶ YES',
+				'    NO',
+				'',
+				'...',
+				'',
+				'✨ Adam has joined the party!',
+				'redirecting to /contact...'
 			],
-			navigate: "/contact",
-			navigateDelay: 2000,
-		},
+			navigate: '/contact',
+			navigateDelay: 2000
+		}
 	},
 
-	"git log": {
+	'git log': {
 		terminal: {
 			lines: [
-				"a3f9c12  fix: stop auth tokens escaping into the void",
-				"b812dd0  feat: forge the OAuth integration at last",
-				"cc4491e  refactor: untangle the spaghetti dungeon (again)",
-				"d009fe1  chore: resupply at the npm registry",
-				"e774a30  feat: survive the aws crash course",
-				"f1b2c33  fix: the legacy php stronghold holds one more day",
-				"g7h8i99  docs: write the readme nobody asked for",
-			],
+				'a3f9c12  fix: stop auth tokens escaping into the void',
+				'b812dd0  feat: forge the OAuth integration at last',
+				'cc4491e  refactor: untangle the spaghetti dungeon (again)',
+				'd009fe1  chore: resupply at the npm registry',
+				'e774a30  feat: survive the aws crash course',
+				'f1b2c33  fix: the legacy php stronghold holds one more day',
+				'g7h8i99  docs: write the readme nobody asked for'
+			]
 		},
 		rpg: {
 			lines: [
-				"a3f9c12  fix: slew the null pointer demon (again)",
-				"b812dd0  feat: forged the OAuth amulet",
-				"cc4491e  refactor: untangled the spaghetti dungeon",
-				"d009fe1  chore: resupplied at the npm inn",
-				"e774a30  docs: transcribed the ancient CLAUDE.md scrolls",
-			],
-		},
+				'a3f9c12  fix: slew the null pointer demon (again)',
+				'b812dd0  feat: forged the OAuth amulet',
+				'cc4491e  refactor: untangled the spaghetti dungeon',
+				'd009fe1  chore: resupplied at the npm inn',
+				'e774a30  docs: transcribed the ancient CLAUDE.md scrolls'
+			]
+		}
 	},
 
-	"rm -rf .": {
-		terminal: { lines: ["nice try."] },
+	'rm -rf .': {
+		terminal: { lines: ['nice try.'] },
 		rpg: {
 			lines: [
-				"⚠ DANGER",
-				"this action would destroy the known world.",
-				"the spirits of /bin refuse your request.",
-			],
-		},
+				'⚠ DANGER',
+				'this action would destroy the known world.',
+				'the spirits of /bin refuse your request.'
+			]
+		}
 	},
 
 	vim: {
 		terminal: { lines: ["you're already in a terminal. don't push it."] },
 		rpg: {
 			lines: [
-				"a cursed editor. many have entered.",
-				"few have exited.",
-				"[ press :q to escape... if you can. ]",
-			],
-		},
+				'a cursed editor. many have entered.',
+				'few have exited.',
+				'[ press :q to escape... if you can. ]'
+			]
+		}
 	},
 
-	"mode rpg": {
+	'mode rpg': {
 		terminal: {
 			lines: [
-				"",
-				"  *  .  *  .  *  .  *  .  *  .  *",
-				"",
-				"  __     /\\  /\\  /\\     __",
-				" /o \\~  /  \\/  \\/  \\  ~/o \\",
-				"/____\\ |____________| /____\\",
-				"  ||                    ||",
-				"",
-				"    ____  ____   ____ ",
-				"   |  _ \\|  _ \\ / ___|",
-				"   | |_) | |_) || |  _",
-				"   |  _ <|  __/ | |_| |",
-				"   |_| \\_\\|_|   \\____|",
-				"",
-				"            M O D E",
-				"",
-				"  *  .  *  .  *  .  *  .  *  .  *",
-				"",
-				"  the spirits of the console stir...",
+				'',
+				'  *  .  *  .  *  .  *  .  *  .  *',
+				'',
+				'  __     /\\  /\\  /\\     __',
+				' /o \\~  /  \\/  \\/  \\  ~/o \\',
+				'/____\\ |____________| /____\\',
+				'  ||                    ||',
+				'',
+				'    ____  ____   ____ ',
+				'   |  _ \\|  _ \\ / ___|',
+				'   | |_) | |_) || |  _',
+				'   |  _ <|  __/ | |_| |',
+				'   |_| \\_\\|_|   \\____|',
+				'',
+				'            M O D E',
+				'',
+				'  *  .  *  .  *  .  *  .  *  .  *',
+				'',
+				'  the spirits of the console stir...'
 			],
-			modeChange: "rpg",
-		},
+			modeChange: 'rpg'
+		}
 	},
 
-	"rpg mode": {
+	'rpg mode': {
 		terminal: {
 			lines: [
-				"",
-				"  *  .  *  .  *  .  *  .  *  .  *",
-				"",
-				"  __     /\\  /\\  /\\     __",
-				" /o \\~  /  \\/  \\/  \\  ~/o \\",
-				"/____\\ |____________| /____\\",
-				"  ||                    ||",
-				"",
-				"    ____  ____   ____ ",
-				"   |  _ \\|  _ \\ / ___|",
-				"   | |_) | |_) || |  _",
-				"   |  _ <|  __/ | |_| |",
-				"   |_| \\_\\|_|   \\____|",
-				"",
-				"            M O D E",
-				"",
-				"  *  .  *  .  *  .  *  .  *  .  *",
-				"",
-				"  the spirits of the console stir...",
+				'',
+				'  *  .  *  .  *  .  *  .  *  .  *',
+				'',
+				'  __     /\\  /\\  /\\     __',
+				' /o \\~  /  \\/  \\/  \\  ~/o \\',
+				'/____\\ |____________| /____\\',
+				'  ||                    ||',
+				'',
+				'    ____  ____   ____ ',
+				'   |  _ \\|  _ \\ / ___|',
+				'   | |_) | |_) || |  _',
+				'   |  _ <|  __/ | |_| |',
+				'   |_| \\_\\|_|   \\____|',
+				'',
+				'            M O D E',
+				'',
+				'  *  .  *  .  *  .  *  .  *  .  *',
+				'',
+				'  the spirits of the console stir...'
 			],
-			modeChange: "rpg",
-		},
+			modeChange: 'rpg'
+		}
 	},
 
-	"mode terminal": {
+	'mode terminal': {
 		terminal: {
-			lines: ["RPG mode disabled. back to reality."],
-			modeChange: "terminal",
-		},
+			lines: ['RPG mode disabled. back to reality.'],
+			modeChange: 'terminal'
+		}
 	},
 
 	chocobo: {
 		terminal: {
 			lines: [
-				"kweh!",
-				"",
-				"a golden chocobo has appeared.",
-				"RPG mode unlocked. type 'mode rpg' to activate.",
+				'kweh!',
+				'',
+				'a golden chocobo has appeared.',
+				"RPG mode unlocked. type 'mode rpg' to activate."
 			],
-			rpgUnlock: true,
-		},
+			rpgUnlock: true
+		}
 	},
 
 	zelda: {
 		terminal: {
-			lines: ["it's dangerous to code alone. take this.", "", "  ⚔", ""],
-			rpgUnlock: true,
-		},
+			lines: ["it's dangerous to code alone. take this.", '', '  ⚔', ''],
+			rpgUnlock: true
+		}
 	},
 
 	ritual: {
 		terminal: {
 			lines: [
-				"✶ THE HIDDEN RUNES ✶",
-				"konami whisper: ↑ ↑ ↓ ↓ ← → ← → B A",
-				"secret phrase: ex codice lumen",
-				`translation: "${INCANTATIONS["ex codice lumen"]}"`,
-				"rune coordinates: 41.78°N, 71.44°W",
-				"codex: v3.1.7",
-				"last rite (hex): 0x680F4E00",
-				"moon phase: Waxing Gibbous",
-			],
-		},
+				'✶ THE HIDDEN RUNES ✶',
+				'konami whisper: ↑ ↑ ↓ ↓ ← → ← → B A',
+				'secret phrase: ex codice lumen',
+				`translation: "${INCANTATIONS['ex codice lumen']}"`,
+				'rune coordinates: 41.78°N, 71.44°W',
+				'codex: v3.1.7',
+				'last rite (hex): 0x680F4E00',
+				'moon phase: Waxing Gibbous'
+			]
+		}
 	},
 
-	"translate ex codice lumen": {
+	'translate ex codice lumen': {
 		terminal: {
-			lines: ['ex codice lumen → "from code, light"'],
-		},
+			lines: ['ex codice lumen → "from code, light"']
+		}
 	},
 
 	summon: {
 		terminal: {
 			lines: [
-				"summon endpoints:",
-				"  /api/github",
-				"  /api/sitemap",
-				"  /humans.txt",
-				"  /llms.txt",
-			],
-		},
+				'summon endpoints:',
+				'  /api/github',
+				'  /api/sitemap',
+				'  /humans.txt',
+				'  /llms.txt'
+			]
+		}
 	},
 
 	severed: {
 		terminal: {
-			lines: ["elevator descending to /severed..."],
-			navigate: "/severed",
-			navigateDelay: 700,
+			lines: ['elevator descending to /severed...'],
+			navigate: '/severed',
+			navigateDelay: 700
 		},
 		innie: {
-			lines: ["badge accepted. descending to /severed..."],
-			navigate: "/severed",
-			navigateDelay: 700,
-		},
-	},
+			lines: ['badge accepted. descending to /severed...'],
+			navigate: '/severed',
+			navigateDelay: 700
+		}
+	}
 };
 
 export function runCommand(rawInput: string, mode: Mode): CommandResult {
@@ -437,44 +432,38 @@ export function runCommand(rawInput: string, mode: Mode): CommandResult {
 	const lower = input.toLowerCase();
 
 	if (!input) return { lines: [] };
-	if (lower === "clear") return { lines: [], clear: true };
-	if (lower === "exit" || lower === "quit") return { lines: [], close: true };
+	if (lower === 'clear') return { lines: [], clear: true };
+	if (lower === 'exit' || lower === 'quit') return { lines: [], close: true };
 
-	if (lower.startsWith("translate ")) {
-		const phrase = lower.slice("translate ".length).trim();
+	if (lower.startsWith('translate ')) {
+		const phrase = lower.slice('translate '.length).trim();
 		const translation = INCANTATIONS[phrase];
 		if (translation) return { lines: [`${phrase} → "${translation}"`] };
 		return {
-			lines: [
-				`unknown incantation: ${phrase}`,
-				"try: translate ex codice lumen",
-			],
+			lines: [`unknown incantation: ${phrase}`, 'try: translate ex codice lumen']
 		};
 	}
 
 	const key = normalize(lower);
 	const def = commands[key];
 	if (def) {
-		if (mode === "rpg" && def.rpg) return def.rpg;
-		if (mode === "innie" && def.innie) return def.innie;
+		if (mode === 'rpg' && def.rpg) return def.rpg;
+		if (mode === 'innie' && def.innie) return def.innie;
 		return def.terminal;
 	}
 
 	return {
-		lines: [
-			`command not found: ${input}`,
-			"type 'help' for available commands.",
-		],
+		lines: [`command not found: ${input}`, "type 'help' for available commands."]
 	};
 }
 
 const argMap: Record<string, string[]> = {
-	ls: ["work", "/work", "stack", "/stack"],
-	cat: ["resume.txt"],
-	open: ["hire", "/hire"],
-	git: ["log"],
-	mode: ["rpg", "terminal"],
-	sudo: ["hire adam"],
+	ls: ['work', '/work', 'stack', '/stack'],
+	cat: ['resume.txt'],
+	open: ['hire', '/hire'],
+	git: ['log'],
+	mode: ['rpg', 'terminal'],
+	sudo: ['hire adam'],
 	ritual: [],
 	summon: [],
 	translate: Object.keys(INCANTATIONS),
@@ -482,42 +471,42 @@ const argMap: Record<string, string[]> = {
 	outie: [],
 	macrodata: [],
 	waffleparty: [],
-	severed: [],
+	severed: []
 };
 
 const topLevelCommands = [
-	"whoami",
-	"help",
-	"-h",
-	"ls",
-	"cat",
-	"contact",
-	"open",
-	"echo",
-	"git",
-	"sudo",
-	"clear",
-	"exit",
-	"quit",
-	"rm",
-	"vim",
-	"vi",
-	"nano",
-	"emacs",
-	"mode",
-	"chocobo",
-	"ritual",
-	"summon",
-	"translate",
-	"innie",
-	"outie",
-	"macrodata",
-	"waffleparty",
-	"severed",
+	'whoami',
+	'help',
+	'-h',
+	'ls',
+	'cat',
+	'contact',
+	'open',
+	'echo',
+	'git',
+	'sudo',
+	'clear',
+	'exit',
+	'quit',
+	'rm',
+	'vim',
+	'vi',
+	'nano',
+	'emacs',
+	'mode',
+	'chocobo',
+	'ritual',
+	'summon',
+	'translate',
+	'innie',
+	'outie',
+	'macrodata',
+	'waffleparty',
+	'severed'
 ];
 
 export function getCompletions(input: string): string[] {
-	const tokens = input.split(" ");
+	const tokens = input.split(' ');
 
 	if (tokens.length === 1) {
 		const partial = tokens[0].toLowerCase();
@@ -525,7 +514,7 @@ export function getCompletions(input: string): string[] {
 	}
 
 	const cmd = tokens[0].toLowerCase();
-	const partial = tokens.slice(1).join(" ").toLowerCase();
+	const partial = tokens.slice(1).join(' ').toLowerCase();
 	const args = argMap[cmd] ?? [];
 	return args.filter((a) => a.startsWith(partial));
 }

--- a/src/lib/terminal-state.svelte.ts
+++ b/src/lib/terminal-state.svelte.ts
@@ -1,88 +1,72 @@
-import { goto } from "$app/navigation";
-import {
-	runCommand,
-	normalize,
-	getCompletions,
-	type Mode,
-} from "$lib/terminal-commands";
-import {
-	trackTerminalOpen,
-	trackTerminalCommand,
-	trackTerminalModeChange,
-} from "$lib/analytics";
-import { getSeveranceMode, setSeveranceMode } from "$lib/stores/severance";
+import { goto } from '$app/navigation';
+import { runCommand, normalize, getCompletions, type Mode } from '$lib/terminal-commands';
+import { trackTerminalOpen, trackTerminalCommand, trackTerminalModeChange } from '$lib/analytics';
+import { getSeveranceMode, setSeveranceMode } from '$lib/stores/severance';
 
 export type HistoryEntry =
-	| { id: number; type: "input"; text: string }
-	| { id: number; type: "output"; lines: string[] };
+	| { id: number; type: 'input'; text: string }
+	| { id: number; type: 'output'; lines: string[] };
 
 export class TerminalState {
 	isOpen = $state(false);
-	input = $state("");
+	input = $state('');
 	history = $state<HistoryEntry[]>([]);
 	cmdHistory = $state<string[]>([]);
 	cmdHistoryIndex = $state(-1);
-	mode = $state<Mode>("terminal");
+	mode = $state<Mode>('terminal');
 	#nextId = 0;
 	#fullscreen: () => boolean;
 	#navigate: (path: string) => Promise<void>;
 	#mdrActive = false;
 	#mdrScore = { woe: 0, frolic: 0, dread: 0, malice: 0 };
-	#memory: Record<
-		"outie" | "innie",
-		{ history: HistoryEntry[]; cmdHistory: string[] }
-	> = {
+	#memory: Record<'outie' | 'innie', { history: HistoryEntry[]; cmdHistory: string[] }> = {
 		outie: { history: [], cmdHistory: [] },
-		innie: { history: [], cmdHistory: [] },
+		innie: { history: [], cmdHistory: [] }
 	};
 
 	constructor(
 		fullscreen: boolean | (() => boolean) = false,
-		navigate: (path: string) => Promise<void> = goto,
+		navigate: (path: string) => Promise<void> = goto
 	) {
-		this.#fullscreen =
-			typeof fullscreen === "function" ? fullscreen : () => fullscreen;
+		this.#fullscreen = typeof fullscreen === 'function' ? fullscreen : () => fullscreen;
 		this.#navigate = navigate;
-		this.mode = getSeveranceMode() === "innie" ? "innie" : "terminal";
+		this.mode = getSeveranceMode() === 'innie' ? 'innie' : 'terminal';
 		this.#loadMemory(this.#modeMemoryKey(this.mode));
 	}
 
-	open(source: "keyboard" | "button" | "page" = "keyboard", initialChar = "") {
+	open(source: 'keyboard' | 'button' | 'page' = 'keyboard', initialChar = '') {
 		this.isOpen = true;
 		this.input = initialChar;
 		trackTerminalOpen(source);
 	}
 
 	isInnieMode() {
-		return this.mode === "innie";
+		return this.mode === 'innie';
 	}
 
 	isRpgMode() {
-		return this.mode === "rpg";
+		return this.mode === 'rpg';
 	}
 
 	close() {
 		if (this.#fullscreen()) return;
 		this.isOpen = false;
-		this.input = "";
+		this.input = '';
 	}
 
 	submit() {
 		const cmd = this.input.trim();
-		this.input = "";
+		this.input = '';
 		if (!cmd) return;
 
-		this.history = [
-			...this.history,
-			{ id: this.#nextId++, type: "input", text: cmd },
-		];
+		this.history = [...this.history, { id: this.#nextId++, type: 'input', text: cmd }];
 		this.cmdHistory = [cmd, ...this.cmdHistory.slice(0, 49)];
 		this.cmdHistoryIndex = -1;
 
 		const lower = cmd.toLowerCase();
 
-		if (this.mode === "innie" && this.#handleMacrodataFlow(lower)) {
-			trackTerminalCommand("macrodata", this.mode);
+		if (this.mode === 'innie' && this.#handleMacrodataFlow(lower)) {
+			trackTerminalCommand('macrodata', this.mode);
 			return;
 		}
 
@@ -91,10 +75,10 @@ export class TerminalState {
 
 		// Track recognized commands only — avoid logging free-text typos
 		if (
-			lower === "clear" ||
-			lower === "exit" ||
-			lower === "quit" ||
-			!result.lines[0]?.startsWith("command not found")
+			lower === 'clear' ||
+			lower === 'exit' ||
+			lower === 'quit' ||
+			!result.lines[0]?.startsWith('command not found')
 		) {
 			trackTerminalCommand(key, this.mode);
 		}
@@ -110,18 +94,15 @@ export class TerminalState {
 		}
 
 		if (result.lines.length > 0) {
-			this.history = [
-				...this.history,
-				{ id: this.#nextId++, type: "output", lines: result.lines },
-			];
+			this.history = [...this.history, { id: this.#nextId++, type: 'output', lines: result.lines }];
 		}
 
 		if (result.modeChange) {
 			const previousMode = this.mode;
 			trackTerminalModeChange(result.modeChange);
 			this.mode = result.modeChange;
-			if (result.modeChange === "innie") setSeveranceMode("innie");
-			if (result.modeChange === "terminal") setSeveranceMode("outie");
+			if (result.modeChange === 'innie') setSeveranceMode('innie');
+			if (result.modeChange === 'terminal') setSeveranceMode('outie');
 			this.#switchMemoryIfNeeded(previousMode, result.modeChange);
 		}
 
@@ -134,19 +115,15 @@ export class TerminalState {
 		}
 	}
 
-	navigateHistory(direction: "up" | "down") {
-		if (direction === "up") {
-			const next = Math.min(
-				this.cmdHistoryIndex + 1,
-				this.cmdHistory.length - 1,
-			);
+	navigateHistory(direction: 'up' | 'down') {
+		if (direction === 'up') {
+			const next = Math.min(this.cmdHistoryIndex + 1, this.cmdHistory.length - 1);
 			this.cmdHistoryIndex = next;
-			if (this.cmdHistory[next] !== undefined)
-				this.input = this.cmdHistory[next];
+			if (this.cmdHistory[next] !== undefined) this.input = this.cmdHistory[next];
 		} else {
 			const next = this.cmdHistoryIndex - 1;
 			this.cmdHistoryIndex = next;
-			this.input = next < 0 ? "" : (this.cmdHistory[next] ?? "");
+			this.input = next < 0 ? '' : (this.cmdHistory[next] ?? '');
 		}
 	}
 
@@ -154,55 +131,43 @@ export class TerminalState {
 		const completions = getCompletions(this.input);
 		if (completions.length === 0) return;
 		if (completions.length === 1) {
-			const tokens = this.input.split(" ");
-			const argCommands = [
-				"ls",
-				"cat",
-				"open",
-				"git",
-				"sudo",
-				"mode",
-				"echo",
-				"translate",
-			];
+			const tokens = this.input.split(' ');
+			const argCommands = ['ls', 'cat', 'open', 'git', 'sudo', 'mode', 'echo', 'translate'];
 			if (tokens.length === 1) {
 				this.input = completions[0];
-				if (argCommands.includes(completions[0])) this.input += " ";
+				if (argCommands.includes(completions[0])) this.input += ' ';
 			} else {
 				tokens[tokens.length - 1] = completions[0];
-				this.input = tokens.join(" ");
+				this.input = tokens.join(' ');
 			}
 		} else {
 			this.history = [
 				...this.history,
 				{
 					id: this.#nextId++,
-					type: "output",
-					lines: [completions.join("   ")],
-				},
+					type: 'output',
+					lines: [completions.join('   ')]
+				}
 			];
 		}
 	}
 
 	#pushOutput(lines: string[]) {
-		this.history = [
-			...this.history,
-			{ id: this.#nextId++, type: "output", lines },
-		];
+		this.history = [...this.history, { id: this.#nextId++, type: 'output', lines }];
 	}
 
-	#modeMemoryKey(mode: Mode): "outie" | "innie" {
-		return mode === "innie" ? "innie" : "outie";
+	#modeMemoryKey(mode: Mode): 'outie' | 'innie' {
+		return mode === 'innie' ? 'innie' : 'outie';
 	}
 
-	#saveMemory(key: "outie" | "innie") {
+	#saveMemory(key: 'outie' | 'innie') {
 		this.#memory[key] = {
 			history: [...this.history],
-			cmdHistory: [...this.cmdHistory],
+			cmdHistory: [...this.cmdHistory]
 		};
 	}
 
-	#loadMemory(key: "outie" | "innie") {
+	#loadMemory(key: 'outie' | 'innie') {
 		this.history = [...this.#memory[key].history];
 		this.cmdHistory = [...this.#memory[key].cmdHistory];
 		this.cmdHistoryIndex = -1;
@@ -214,76 +179,63 @@ export class TerminalState {
 		if (prevKey === nextKey) return;
 		this.#saveMemory(prevKey);
 		this.#loadMemory(nextKey);
-		if (nextKey === "innie" && this.history.length === 0) {
-			this.#pushOutput([
-				"memory partition complete.",
-				"type 'macrodata' to begin refinement.",
-			]);
+		if (nextKey === 'innie' && this.history.length === 0) {
+			this.#pushOutput(['memory partition complete.', "type 'macrodata' to begin refinement."]);
 		}
-		if (nextKey === "outie" && this.history.length === 0) {
-			this.#pushOutput([
-				"outie memory restored. no retained innie logs visible.",
-			]);
+		if (nextKey === 'outie' && this.history.length === 0) {
+			this.#pushOutput(['outie memory restored. no retained innie logs visible.']);
 		}
 	}
 
 	#handleMacrodataFlow(lower: string): boolean {
-		if (!this.#mdrActive && lower !== "macrodata") return false;
-		if (!this.#mdrActive && lower === "macrodata") {
+		if (!this.#mdrActive && lower !== 'macrodata') return false;
+		if (!this.#mdrActive && lower === 'macrodata') {
 			this.#mdrActive = true;
 			this.#mdrScore = { woe: 0, frolic: 0, dread: 0, malice: 0 };
 			this.#pushOutput([
-				"MDR SESSION STARTED",
-				"sort with: refine <woe|frolic|dread|malice> <1-40>",
-				"complete 100 total to finish. type abort to exit.",
+				'MDR SESSION STARTED',
+				'sort with: refine <woe|frolic|dread|malice> <1-40>',
+				'complete 100 total to finish. type abort to exit.'
 			]);
 			return true;
 		}
 
-		if (lower === "abort") {
+		if (lower === 'abort') {
 			this.#mdrActive = false;
-			this.#pushOutput(["refinement session closed."]);
+			this.#pushOutput(['refinement session closed.']);
 			return true;
 		}
 
-		const match = lower.match(
-			/^refine\s+(woe|frolic|dread|malice)\s+(\d{1,2})$/,
-		);
+		const match = lower.match(/^refine\s+(woe|frolic|dread|malice)\s+(\d{1,2})$/);
 		if (!match) {
 			this.#pushOutput([
-				"invalid refinement input.",
-				"usage: refine <woe|frolic|dread|malice> <1-40>",
+				'invalid refinement input.',
+				'usage: refine <woe|frolic|dread|malice> <1-40>'
 			]);
 			return true;
 		}
 
-		type MdrBucket = "woe" | "frolic" | "dread" | "malice";
+		type MdrBucket = 'woe' | 'frolic' | 'dread' | 'malice';
 		const bucket = match[1] as MdrBucket;
 		const amount = Number(match[2]);
 		if (amount < 1 || amount > 40) {
-			this.#pushOutput(["refinement amount out of range. use 1-40."]);
+			this.#pushOutput(['refinement amount out of range. use 1-40.']);
 			return true;
 		}
 
 		this.#mdrScore[bucket] += amount;
-		const total = Object.values(this.#mdrScore).reduce(
-			(sum, value) => sum + value,
-			0,
-		);
+		const total = Object.values(this.#mdrScore).reduce((sum, value) => sum + value, 0);
 
 		if (total >= 100) {
 			this.#mdrActive = false;
 			this.#pushOutput([
 				`refinement complete at ${total} points.`,
-				"the work remains mysterious and important.",
+				'the work remains mysterious and important.'
 			]);
 			return true;
 		}
 
-		this.#pushOutput([
-			`${bucket} +${amount} accepted.`,
-			`progress: ${total}/100`,
-		]);
+		this.#pushOutput([`${bucket} +${amount} accepted.`, `progress: ${total}/100`]);
 		return true;
 	}
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 	import WorkCard from '../components/work-card.svelte';
 	import TrustStrip from '../components/trust-strip.svelte';
 	import RecentlyShipped from '../components/recently-shipped.svelte';
+	import OutcomeProof from '../components/outcome-proof.svelte';
 	import { selectedWork, techStack } from '$lib/copy';
 	import { setupScrollAnimations } from '$lib/animations';
 	import { onMount } from 'svelte';
@@ -105,6 +106,7 @@
 <div class="max-w-3xl mx-auto px-6" class:rune-glow={showRuneToast} bind:this={mainContainer}>
 	<HeroSection />
 	<TrustStrip />
+	<OutcomeProof />
 	<RecentlyShipped />
 
 	<!-- Tech Stack -->

--- a/src/routes/api/contact/+server.ts
+++ b/src/routes/api/contact/+server.ts
@@ -1,21 +1,35 @@
-import { json } from '@sveltejs/kit';
-import type { RequestHandler } from './$types';
-import { validateEmail, validateContactForm, type ContactFormData } from '$lib/validation';
-import { isRateLimited } from '$lib/server/rateLimit';
-import { sendContactNotification, logFailedSubmission } from '$lib/server/contactEmail';
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+import {
+	validateEmail,
+	validateContactForm,
+	type ContactFormData,
+} from "$lib/validation";
+import { isRateLimited } from "$lib/server/rateLimit";
+import {
+	sendContactNotification,
+	logFailedSubmission,
+	formatInquirySubject,
+} from "$lib/server/contactEmail";
 
 export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	const clientIP = getClientAddress();
 
 	try {
-		if (!request.headers.get('content-type')?.includes('application/json')) {
-			return json({ error: 'Content-Type must be application/json' }, { status: 400 });
+		if (!request.headers.get("content-type")?.includes("application/json")) {
+			return json(
+				{ error: "Content-Type must be application/json" },
+				{ status: 400 },
+			);
 		}
 
 		if (await isRateLimited(clientIP)) {
 			return json(
-				{ error: 'Too many submissions. Please wait 15 minutes before trying again.' },
-				{ status: 429 }
+				{
+					error:
+						"Too many submissions. Please wait 15 minutes before trying again.",
+				},
+				{ status: 429 },
 			);
 		}
 
@@ -23,85 +37,95 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		try {
 			data = await request.json();
 		} catch {
-			return json({ error: 'Invalid JSON body' }, { status: 400 });
+			return json({ error: "Invalid JSON body" }, { status: 400 });
 		}
 
 		// Honeypot — bots fill fields humans don't see; fail silently
 		if (data.website) {
 			return json({
 				success: true,
-				message: "Thank you for your message! I'll respond within 24 hours."
+				message: "Thank you for your message! I'll respond within 24 hours.",
 			});
 		}
 
 		if (!data.name || !data.email || !data.project || !data.message) {
-			return json({ error: 'Missing required fields' }, { status: 400 });
+			return json({ error: "Missing required fields" }, { status: 400 });
 		}
 
 		if (!validateEmail(data.email)) {
-			return json({ error: 'Invalid email format' }, { status: 400 });
+			return json({ error: "Invalid email format" }, { status: 400 });
 		}
 
 		const sanitized: ContactFormData = {
 			name: data.name.trim().slice(0, 100),
 			email: data.email.trim().slice(0, 100),
 			project: data.project.trim().slice(0, 100),
-			timeline: data.timeline?.trim().slice(0, 60) || '',
-			budget: data.budget?.trim().slice(0, 60) || '',
+			timeline: data.timeline?.trim().slice(0, 60) || "",
+			budget: data.budget?.trim().slice(0, 60) || "",
 			message: data.message.trim().slice(0, 2000),
-			phone: data.phone?.trim().slice(0, 20) || ''
+			phone: data.phone?.trim().slice(0, 20) || "",
 		};
 
 		const validation = validateContactForm(sanitized);
 		if (!validation.isValid) {
-			const firstError = Object.values(validation.errors)[0] || 'Invalid form data';
+			const firstError =
+				Object.values(validation.errors)[0] || "Invalid form data";
 			return json({ error: firstError }, { status: 400 });
 		}
 
-		const subject = `New Project Inquiry from ${sanitized.name}`;
+		const subject = formatInquirySubject(
+			sanitized.name,
+			sanitized.project || "",
+		);
 
 		try {
 			await sendContactNotification(sanitized, subject);
 			return json({
 				success: true,
-				message: "Thank you for your message! I'll respond within 24 hours."
+				message: "Thank you for your message! I'll respond within 24 hours.",
 			});
 		} catch (emailError) {
-			console.error('📧 Email delivery failed — logging submission to Redis:', emailError);
+			console.error(
+				"📧 Email delivery failed — logging submission to Redis:",
+				emailError,
+			);
 			const plainBody = [
-				'New contact form submission from adamrobinson.tech:',
+				"New contact form submission from adamrobinson.tech:",
 				`Name: ${sanitized.name}`,
 				`Email: ${sanitized.email}`,
-				`Phone: ${sanitized.phone || 'Not provided'}`,
+				`Phone: ${sanitized.phone || "Not provided"}`,
 				`Project Type: ${sanitized.project}`,
-				`Timeline: ${sanitized.timeline || 'Not provided'}`,
-				`Budget: ${sanitized.budget || 'Not provided'}`,
-				'',
-				'Message:',
+				`Timeline: ${sanitized.timeline || "Not provided"}`,
+				`Budget: ${sanitized.budget || "Not provided"}`,
+				"",
+				"Message:",
 				sanitized.message,
-				'---',
+				"---",
 				`Submitted at: ${new Date().toISOString()}`,
 				`IP: ${clientIP}`,
-				`User-Agent: ${request.headers.get('user-agent') || 'Unknown'}`
-			].join('\n');
+				`User-Agent: ${request.headers.get("user-agent") || "Unknown"}`,
+			].join("\n");
 			const logged = await logFailedSubmission(sanitized, plainBody, clientIP);
 			if (!logged) {
 				return json(
 					{
 						error:
-							'Email delivery failed and the submission could not be saved. Please email me directly.'
+							"Email delivery failed and the submission could not be saved. Please email me directly.",
 					},
-					{ status: 503 }
+					{ status: 503 },
 				);
 			}
 			return json({
 				success: true,
 				message:
-					"Message received — there was a hiccup on our end but your submission was saved. I'll follow up shortly."
+					"Message received — there was a hiccup on our end but your submission was saved. I'll follow up shortly.",
 			});
 		}
 	} catch (error) {
-		console.error('Contact form error:', error);
-		return json({ error: 'Failed to process form submission' }, { status: 500 });
+		console.error("Contact form error:", error);
+		return json(
+			{ error: "Failed to process form submission" },
+			{ status: 500 },
+		);
 	}
 };

--- a/src/routes/api/contact/+server.ts
+++ b/src/routes/api/contact/+server.ts
@@ -1,35 +1,73 @@
-import { json } from "@sveltejs/kit";
-import type { RequestHandler } from "./$types";
-import {
-	validateEmail,
-	validateContactForm,
-	type ContactFormData,
-} from "$lib/validation";
-import { isRateLimited } from "$lib/server/rateLimit";
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { validateEmail, validateContactForm, type ContactFormData } from '$lib/validation';
+import { isRateLimited } from '$lib/server/rateLimit';
 import {
 	sendContactNotification,
 	logFailedSubmission,
-	formatInquirySubject,
-} from "$lib/server/contactEmail";
+	formatInquirySubject
+} from '$lib/server/contactEmail';
+
+const SUCCESS_MESSAGE = "Thank you for your message! I'll respond within 24 hours.";
+const FALLBACK_SUCCESS_MESSAGE =
+	"Message received — there was a hiccup on our end but your submission was saved. I'll follow up shortly.";
+
+type RequiredContactFields = ContactFormData & {
+	name: string;
+	email: string;
+	project: string;
+	message: string;
+};
+
+function sanitizeContactData(data: RequiredContactFields): ContactFormData {
+	return {
+		name: data.name.trim().slice(0, 100),
+		email: data.email.trim().slice(0, 100),
+		project: data.project.trim().slice(0, 100),
+		timeline: data.timeline?.trim().slice(0, 60) || '',
+		budget: data.budget?.trim().slice(0, 60) || '',
+		message: data.message.trim().slice(0, 2000),
+		phone: data.phone?.trim().slice(0, 20) || ''
+	};
+}
+
+function buildFailedSubmissionBody(
+	data: ContactFormData,
+	ip: string,
+	userAgent: string | null
+): string {
+	return [
+		'New contact form submission from adamrobinson.tech:',
+		`Name: ${data.name}`,
+		`Email: ${data.email}`,
+		`Phone: ${data.phone || 'Not provided'}`,
+		`Project Type: ${data.project}`,
+		`Timeline: ${data.timeline || 'Not provided'}`,
+		`Budget: ${data.budget || 'Not provided'}`,
+		'',
+		'Message:',
+		data.message,
+		'---',
+		`Submitted at: ${new Date().toISOString()}`,
+		`IP: ${ip}`,
+		`User-Agent: ${userAgent || 'Unknown'}`
+	].join('\n');
+}
 
 export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	const clientIP = getClientAddress();
 
 	try {
-		if (!request.headers.get("content-type")?.includes("application/json")) {
-			return json(
-				{ error: "Content-Type must be application/json" },
-				{ status: 400 },
-			);
+		if (!request.headers.get('content-type')?.includes('application/json')) {
+			return json({ error: 'Content-Type must be application/json' }, { status: 400 });
 		}
 
 		if (await isRateLimited(clientIP)) {
 			return json(
 				{
-					error:
-						"Too many submissions. Please wait 15 minutes before trying again.",
+					error: 'Too many submissions. Please wait 15 minutes before trying again.'
 				},
-				{ status: 429 },
+				{ status: 429 }
 			);
 		}
 
@@ -37,95 +75,58 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		try {
 			data = await request.json();
 		} catch {
-			return json({ error: "Invalid JSON body" }, { status: 400 });
+			return json({ error: 'Invalid JSON body' }, { status: 400 });
 		}
 
 		// Honeypot — bots fill fields humans don't see; fail silently
 		if (data.website) {
-			return json({
-				success: true,
-				message: "Thank you for your message! I'll respond within 24 hours.",
-			});
+			return json({ success: true, message: SUCCESS_MESSAGE });
 		}
 
 		if (!data.name || !data.email || !data.project || !data.message) {
-			return json({ error: "Missing required fields" }, { status: 400 });
+			return json({ error: 'Missing required fields' }, { status: 400 });
 		}
 
 		if (!validateEmail(data.email)) {
-			return json({ error: "Invalid email format" }, { status: 400 });
+			return json({ error: 'Invalid email format' }, { status: 400 });
 		}
 
-		const sanitized: ContactFormData = {
-			name: data.name.trim().slice(0, 100),
-			email: data.email.trim().slice(0, 100),
-			project: data.project.trim().slice(0, 100),
-			timeline: data.timeline?.trim().slice(0, 60) || "",
-			budget: data.budget?.trim().slice(0, 60) || "",
-			message: data.message.trim().slice(0, 2000),
-			phone: data.phone?.trim().slice(0, 20) || "",
-		};
-
+		const sanitized = sanitizeContactData(data as RequiredContactFields);
 		const validation = validateContactForm(sanitized);
 		if (!validation.isValid) {
-			const firstError =
-				Object.values(validation.errors)[0] || "Invalid form data";
+			const firstError = Object.values(validation.errors)[0] || 'Invalid form data';
 			return json({ error: firstError }, { status: 400 });
 		}
 
-		const subject = formatInquirySubject(
-			sanitized.name,
-			sanitized.project || "",
-		);
+		const subject = formatInquirySubject(sanitized.name, sanitized.project || '');
 
 		try {
 			await sendContactNotification(sanitized, subject);
-			return json({
-				success: true,
-				message: "Thank you for your message! I'll respond within 24 hours.",
-			});
+			return json({ success: true, message: SUCCESS_MESSAGE });
 		} catch (emailError) {
-			console.error(
-				"📧 Email delivery failed — logging submission to Redis:",
-				emailError,
+			console.error('📧 Email delivery failed — logging submission to Redis:', emailError);
+			const plainBody = buildFailedSubmissionBody(
+				sanitized,
+				clientIP,
+				request.headers.get('user-agent')
 			);
-			const plainBody = [
-				"New contact form submission from adamrobinson.tech:",
-				`Name: ${sanitized.name}`,
-				`Email: ${sanitized.email}`,
-				`Phone: ${sanitized.phone || "Not provided"}`,
-				`Project Type: ${sanitized.project}`,
-				`Timeline: ${sanitized.timeline || "Not provided"}`,
-				`Budget: ${sanitized.budget || "Not provided"}`,
-				"",
-				"Message:",
-				sanitized.message,
-				"---",
-				`Submitted at: ${new Date().toISOString()}`,
-				`IP: ${clientIP}`,
-				`User-Agent: ${request.headers.get("user-agent") || "Unknown"}`,
-			].join("\n");
 			const logged = await logFailedSubmission(sanitized, plainBody, clientIP);
 			if (!logged) {
 				return json(
 					{
 						error:
-							"Email delivery failed and the submission could not be saved. Please email me directly.",
+							'Email delivery failed and the submission could not be saved. Please email me directly.'
 					},
-					{ status: 503 },
+					{ status: 503 }
 				);
 			}
 			return json({
 				success: true,
-				message:
-					"Message received — there was a hiccup on our end but your submission was saved. I'll follow up shortly.",
+				message: FALLBACK_SUCCESS_MESSAGE
 			});
 		}
 	} catch (error) {
-		console.error("Contact form error:", error);
-		return json(
-			{ error: "Failed to process form submission" },
-			{ status: 500 },
-		);
+		console.error('Contact form error:', error);
+		return json({ error: 'Failed to process form submission' }, { status: 500 });
 	}
 };

--- a/src/routes/api/contact/contact.test.ts
+++ b/src/routes/api/contact/contact.test.ts
@@ -1,48 +1,43 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { POST } from "./+server";
-import { isRateLimited } from "$lib/server/rateLimit";
-import {
-	logFailedSubmission,
-	sendContactNotification,
-} from "$lib/server/contactEmail";
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from './+server';
+import { isRateLimited } from '$lib/server/rateLimit';
+import { logFailedSubmission, sendContactNotification } from '$lib/server/contactEmail';
 
-vi.mock("$lib/server/rateLimit", () => ({
-	isRateLimited: vi.fn(),
+vi.mock('$lib/server/rateLimit', () => ({
+	isRateLimited: vi.fn()
 }));
 
-vi.mock("$lib/server/contactEmail", () => ({
+vi.mock('$lib/server/contactEmail', () => ({
 	sendContactNotification: vi.fn(),
 	logFailedSubmission: vi.fn(),
-	formatInquirySubject: vi.fn(
-		(name: string) => `[Consulting] New inquiry from ${name}`,
-	),
+	formatInquirySubject: vi.fn((name: string) => `[Consulting] New inquiry from ${name}`)
 }));
 
 const mockIsRateLimited = vi.mocked(isRateLimited);
 const mockSendContactNotification = vi.mocked(sendContactNotification);
 const mockLogFailedSubmission = vi.mocked(logFailedSubmission);
 
-function postContact(body: string, contentType = "application/json") {
+function postContact(body: string, contentType = 'application/json') {
 	return POST({
-		request: new Request("https://adamrobinson.tech/api/contact", {
-			method: "POST",
-			headers: { "content-type": contentType },
-			body,
+		request: new Request('https://adamrobinson.tech/api/contact', {
+			method: 'POST',
+			headers: { 'content-type': contentType },
+			body
 		}),
-		getClientAddress: () => "203.0.113.10",
+		getClientAddress: () => '203.0.113.10'
 	} as Parameters<typeof POST>[0]);
 }
 
 function validPayload() {
 	return {
-		name: "Ada Lovelace",
-		email: "ada@example.com",
-		project: "Technical consulting",
-		message: "I need help stabilizing a SvelteKit application.",
+		name: 'Ada Lovelace',
+		email: 'ada@example.com',
+		project: 'Technical consulting',
+		message: 'I need help stabilizing a SvelteKit application.'
 	};
 }
 
-describe("/api/contact POST", () => {
+describe('/api/contact POST', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockIsRateLimited.mockResolvedValue(false);
@@ -50,32 +45,30 @@ describe("/api/contact POST", () => {
 		mockLogFailedSubmission.mockResolvedValue(true);
 	});
 
-	it("returns 400 for malformed JSON", async () => {
-		const response = await postContact("{bad json");
+	it('returns 400 for malformed JSON', async () => {
+		const response = await postContact('{bad json');
 		const body = await response.json();
 
 		expect(response.status).toBe(400);
-		expect(body).toEqual({ error: "Invalid JSON body" });
+		expect(body).toEqual({ error: 'Invalid JSON body' });
 		expect(mockSendContactNotification).not.toHaveBeenCalled();
 	});
 
-	it("returns success when email delivery succeeds", async () => {
+	it('returns success when email delivery succeeds', async () => {
 		const response = await postContact(JSON.stringify(validPayload()));
 		const body = await response.json();
 
 		expect(response.status).toBe(200);
 		expect(body.success).toBe(true);
 		expect(mockSendContactNotification).toHaveBeenCalledWith(
-			expect.objectContaining({ project: "Technical consulting" }),
-			"[Consulting] New inquiry from Ada Lovelace",
+			expect.objectContaining({ project: 'Technical consulting' }),
+			'[Consulting] New inquiry from Ada Lovelace'
 		);
 		expect(mockLogFailedSubmission).not.toHaveBeenCalled();
 	});
 
-	it("returns success when email delivery fails but fallback logging succeeds", async () => {
-		mockSendContactNotification.mockRejectedValue(
-			new Error("resend unavailable"),
-		);
+	it('returns success when email delivery fails but fallback logging succeeds', async () => {
+		mockSendContactNotification.mockRejectedValue(new Error('resend unavailable'));
 		mockLogFailedSubmission.mockResolvedValue(true);
 
 		const response = await postContact(JSON.stringify(validPayload()));
@@ -83,21 +76,19 @@ describe("/api/contact POST", () => {
 
 		expect(response.status).toBe(200);
 		expect(body.success).toBe(true);
-		expect(body.message).toContain("submission was saved");
+		expect(body.message).toContain('submission was saved');
 		expect(mockLogFailedSubmission).toHaveBeenCalledOnce();
 	});
 
-	it("returns 503 when email delivery and fallback logging both fail", async () => {
-		mockSendContactNotification.mockRejectedValue(
-			new Error("resend unavailable"),
-		);
+	it('returns 503 when email delivery and fallback logging both fail', async () => {
+		mockSendContactNotification.mockRejectedValue(new Error('resend unavailable'));
 		mockLogFailedSubmission.mockResolvedValue(false);
 
 		const response = await postContact(JSON.stringify(validPayload()));
 		const body = await response.json();
 
 		expect(response.status).toBe(503);
-		expect(body.error).toContain("could not be saved");
+		expect(body.error).toContain('could not be saved');
 		expect(mockLogFailedSubmission).toHaveBeenCalledOnce();
 	});
 });

--- a/src/routes/api/contact/contact.test.ts
+++ b/src/routes/api/contact/contact.test.ts
@@ -1,42 +1,48 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { POST } from './+server';
-import { isRateLimited } from '$lib/server/rateLimit';
-import { logFailedSubmission, sendContactNotification } from '$lib/server/contactEmail';
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./+server";
+import { isRateLimited } from "$lib/server/rateLimit";
+import {
+	logFailedSubmission,
+	sendContactNotification,
+} from "$lib/server/contactEmail";
 
-vi.mock('$lib/server/rateLimit', () => ({
-	isRateLimited: vi.fn()
+vi.mock("$lib/server/rateLimit", () => ({
+	isRateLimited: vi.fn(),
 }));
 
-vi.mock('$lib/server/contactEmail', () => ({
+vi.mock("$lib/server/contactEmail", () => ({
 	sendContactNotification: vi.fn(),
-	logFailedSubmission: vi.fn()
+	logFailedSubmission: vi.fn(),
+	formatInquirySubject: vi.fn(
+		(name: string) => `[Consulting] New inquiry from ${name}`,
+	),
 }));
 
 const mockIsRateLimited = vi.mocked(isRateLimited);
 const mockSendContactNotification = vi.mocked(sendContactNotification);
 const mockLogFailedSubmission = vi.mocked(logFailedSubmission);
 
-function postContact(body: string, contentType = 'application/json') {
+function postContact(body: string, contentType = "application/json") {
 	return POST({
-		request: new Request('https://adamrobinson.tech/api/contact', {
-			method: 'POST',
-			headers: { 'content-type': contentType },
-			body
+		request: new Request("https://adamrobinson.tech/api/contact", {
+			method: "POST",
+			headers: { "content-type": contentType },
+			body,
 		}),
-		getClientAddress: () => '203.0.113.10'
+		getClientAddress: () => "203.0.113.10",
 	} as Parameters<typeof POST>[0]);
 }
 
 function validPayload() {
 	return {
-		name: 'Ada Lovelace',
-		email: 'ada@example.com',
-		project: 'Technical consulting',
-		message: 'I need help stabilizing a SvelteKit application.'
+		name: "Ada Lovelace",
+		email: "ada@example.com",
+		project: "Technical consulting",
+		message: "I need help stabilizing a SvelteKit application.",
 	};
 }
 
-describe('/api/contact POST', () => {
+describe("/api/contact POST", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockIsRateLimited.mockResolvedValue(false);
@@ -44,27 +50,32 @@ describe('/api/contact POST', () => {
 		mockLogFailedSubmission.mockResolvedValue(true);
 	});
 
-	it('returns 400 for malformed JSON', async () => {
-		const response = await postContact('{bad json');
+	it("returns 400 for malformed JSON", async () => {
+		const response = await postContact("{bad json");
 		const body = await response.json();
 
 		expect(response.status).toBe(400);
-		expect(body).toEqual({ error: 'Invalid JSON body' });
+		expect(body).toEqual({ error: "Invalid JSON body" });
 		expect(mockSendContactNotification).not.toHaveBeenCalled();
 	});
 
-	it('returns success when email delivery succeeds', async () => {
+	it("returns success when email delivery succeeds", async () => {
 		const response = await postContact(JSON.stringify(validPayload()));
 		const body = await response.json();
 
 		expect(response.status).toBe(200);
 		expect(body.success).toBe(true);
-		expect(mockSendContactNotification).toHaveBeenCalledOnce();
+		expect(mockSendContactNotification).toHaveBeenCalledWith(
+			expect.objectContaining({ project: "Technical consulting" }),
+			"[Consulting] New inquiry from Ada Lovelace",
+		);
 		expect(mockLogFailedSubmission).not.toHaveBeenCalled();
 	});
 
-	it('returns success when email delivery fails but fallback logging succeeds', async () => {
-		mockSendContactNotification.mockRejectedValue(new Error('resend unavailable'));
+	it("returns success when email delivery fails but fallback logging succeeds", async () => {
+		mockSendContactNotification.mockRejectedValue(
+			new Error("resend unavailable"),
+		);
 		mockLogFailedSubmission.mockResolvedValue(true);
 
 		const response = await postContact(JSON.stringify(validPayload()));
@@ -72,19 +83,21 @@ describe('/api/contact POST', () => {
 
 		expect(response.status).toBe(200);
 		expect(body.success).toBe(true);
-		expect(body.message).toContain('submission was saved');
+		expect(body.message).toContain("submission was saved");
 		expect(mockLogFailedSubmission).toHaveBeenCalledOnce();
 	});
 
-	it('returns 503 when email delivery and fallback logging both fail', async () => {
-		mockSendContactNotification.mockRejectedValue(new Error('resend unavailable'));
+	it("returns 503 when email delivery and fallback logging both fail", async () => {
+		mockSendContactNotification.mockRejectedValue(
+			new Error("resend unavailable"),
+		);
 		mockLogFailedSubmission.mockResolvedValue(false);
 
 		const response = await postContact(JSON.stringify(validPayload()));
 		const body = await response.json();
 
 		expect(response.status).toBe(503);
-		expect(body.error).toContain('could not be saved');
+		expect(body.error).toContain("could not be saved");
 		expect(mockLogFailedSubmission).toHaveBeenCalledOnce();
 	});
 });

--- a/src/routes/work/+page.server.ts
+++ b/src/routes/work/+page.server.ts
@@ -1,8 +1,8 @@
-import type { PageServerLoad } from "./$types";
-import { getAnonymizedCaseStudies } from "$lib/server/caseStudies";
+import type { PageServerLoad } from './$types';
+import { getAnonymizedCaseStudies } from '$lib/server/caseStudies';
 
 export const load: PageServerLoad = async () => {
 	return {
-		anonymizedCaseStudies: getAnonymizedCaseStudies(),
+		anonymizedCaseStudies: getAnonymizedCaseStudies()
 	};
 };

--- a/src/routes/work/+page.server.ts
+++ b/src/routes/work/+page.server.ts
@@ -1,0 +1,8 @@
+import type { PageServerLoad } from "./$types";
+import { getAnonymizedCaseStudies } from "$lib/server/caseStudies";
+
+export const load: PageServerLoad = async () => {
+	return {
+		anonymizedCaseStudies: getAnonymizedCaseStudies(),
+	};
+};

--- a/src/routes/work/+page.svelte
+++ b/src/routes/work/+page.svelte
@@ -1,12 +1,30 @@
 <script lang="ts">
+	import type { PageData } from './$types';
 	import { trackCTA } from '$lib/analytics';
 	import SeoHead from '../../components/seo-head.svelte';
 	import PageHeader from '../../components/page-header.svelte';
 	import WorkCard from '../../components/work-card.svelte';
+	import CaseStudy from '../../components/case-study.svelte';
 	import { selectedWork, earlierWork, gitLog } from '$lib/copy';
 	import JsonLd from '../../components/json-ld.svelte';
 	import { breadcrumbList } from '$lib/utils';
 	import { getFilter } from '$lib/stores/work-filter.svelte';
+
+	type AnonymizedCaseStudyView = {
+		slug: string;
+		title: string;
+		audience: string;
+		confidentiality: string;
+		situation: string;
+		approach: string;
+		outcome: string;
+	};
+
+	let { data }: { data: PageData } = $props();
+	const anonymizedCaseStudies = $derived(
+		((data as { anonymizedCaseStudies?: AnonymizedCaseStudyView[] }).anonymizedCaseStudies ??
+			[]) as AnonymizedCaseStudyView[]
+	);
 
 	const filteredWork = $derived.by(() => {
 		const f = getFilter();
@@ -92,6 +110,19 @@
 		{/each}
 	</div>
 
+	<section class="anonymized-work" aria-labelledby="anon-heading">
+		<h2 id="anon-heading" class="earlier-heading">Anonymized case studies</h2>
+		<div class="grid gap-6">
+			{#each anonymizedCaseStudies as study (study.slug)}
+				<article class="trust-item">
+					<h3 class="text-lg mb-1">{study.title}</h3>
+					<p class="muted-text text-sm mb-4">{study.audience} · {study.confidentiality}</p>
+					<CaseStudy situation={study.situation} work={study.approach} outcome={study.outcome} />
+				</article>
+			{/each}
+		</div>
+	</section>
+
 	<section class="earlier-work" aria-labelledby="earlier-heading">
 		<h2 id="earlier-heading" class="earlier-heading">Earlier work</h2>
 		<ul class="earlier-list">
@@ -164,6 +195,12 @@
 
 	.dot {
 		color: var(--color-accent);
+	}
+
+	.anonymized-work {
+		margin-top: 3rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--color-border);
 	}
 
 	.earlier-work {


### PR DESCRIPTION
## Summary
- clarify homepage messaging for both hiring managers and contract clients
- enforce CTA hierarchy (contact form primary, email/résumé secondary)
- add contact inquiry intent routing + subject labeling
- add anonymized case-study pipeline and initial entries on /work
- add interactive outcome timeline module on homepage
- add/expand tests for hero messaging, contact intent routing, case-study schema, and outcome interactions
- add docs artifacts (brainstorm, plan, solution) and ignore local .context artifacts

## Validation
- npm run test -- hero-dual-intent
- npm run test -- contact-intent-routing
- npm run test -- anonymized-case-study-schema
- npm run test -- outcome-proof-interactions
- npm run check
- npm run build

## Notes
- This branch includes workflow docs under docs/brainstorms, docs/plans, and docs/solutions by design.
